### PR TITLE
feat: enable label validation by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ See the [examples/](examples/) directory for complete examples:
 ```yaml
 "linkml_term_validator.plugins.BindingValidationPlugin":
   oak_adapter_string: "sqlite:obo:"  # OAK adapter (default: sqlite:obo:)
-  validate_labels: true               # Check labels match ontology (default: false)
+  validate_labels: true               # Check labels match ontology (default: true)
   cache_labels: true                  # Enable label caching (default: true)
   cache_dir: cache                    # Cache directory (default: cache)
   oak_config_path: oak_config.yaml    # Optional: custom OAK config

--- a/docs/binding-validation.md
+++ b/docs/binding-validation.md
@@ -357,7 +357,7 @@ for result in report.results:
 |-----------|------|---------|-------------|
 | `oak_adapter_string` | `str` | `"sqlite:obo:"` | Default OAK adapter |
 | `oak_config_path` | `str \| None` | `None` | Path to OAK config file |
-| `validate_labels` | `bool` | `False` | Also validate labels |
+| `validate_labels` | `bool` | `True` | Also validate labels |
 | `strict` | `bool` | `True` | Fail when term IDs not found in configured ontologies |
 | `cache_labels` | `bool` | `True` | Enable file-based caching |
 | `cache_dir` | `str` | `"cache"` | Cache directory |

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -289,7 +289,7 @@ from linkml_term_validator.plugins import BindingValidationPlugin
 plugin = BindingValidationPlugin(
     oak_adapter_string="sqlite:obo:",
     oak_config_path=None,
-    validate_labels=False,
+    validate_labels=True,
     cache_labels=True,
     cache_dir="cache",
 )
@@ -301,7 +301,7 @@ plugin = BindingValidationPlugin(
 |-----------|------|---------|-------------|
 | `oak_adapter_string` | `str` | `"sqlite:obo:"` | Default OAK adapter string for ontology access |
 | `oak_config_path` | `str \| None` | `None` | Path to `oak_config.yaml` for per-prefix adapter configuration |
-| `validate_labels` | `bool` | `False` | If `True`, also validate that labels match ontology canonical labels |
+| `validate_labels` | `bool` | `True` | If `True` (default), also validate that labels match ontology canonical labels |
 | `cache_labels` | `bool` | `True` | Enable file-based caching of ontology labels |
 | `cache_dir` | `str` | `"cache"` | Directory for cache files |
 

--- a/src/linkml_term_validator/cli.py
+++ b/src/linkml_term_validator/cli.py
@@ -171,9 +171,9 @@ def validate_data(
         bool,
         typer.Option(
             "--labels/--no-labels",
-            help="Validate labels match ontology",
+            help="Validate labels match ontology (default: enabled)",
         ),
-    ] = False,
+    ] = True,
     lenient: Annotated[
         bool,
         typer.Option(
@@ -406,7 +406,7 @@ def validate_all(
             target_class=None,
             validate_bindings=True,
             validate_dynamic_enums=True,
-            validate_labels=False,
+            validate_labels=True,
             lenient=lenient,
             adapter=adapter,
             cache_dir=cache_dir,

--- a/src/linkml_term_validator/plugins/binding_plugin.py
+++ b/src/linkml_term_validator/plugins/binding_plugin.py
@@ -13,7 +13,7 @@ Example:
     >>> plugin.strict
     True
     >>> plugin.validate_labels
-    False
+    True
     >>> plugin.expanded_enums
     {}
 
@@ -92,7 +92,7 @@ class BindingValidationPlugin(BaseOntologyPlugin):
     def __init__(
         self,
         oak_adapter_string: str = "sqlite:obo:",
-        validate_labels: bool = False,
+        validate_labels: bool = True,
         strict: bool = True,
         cache_labels: bool = True,
         cache_dir: Path | str = Path("cache"),
@@ -103,7 +103,7 @@ class BindingValidationPlugin(BaseOntologyPlugin):
 
         Args:
             oak_adapter_string: Default OAK adapter string (e.g., "sqlite:obo:")
-            validate_labels: If True, also validate that labels match ontology
+            validate_labels: If True (default), also validate that labels match ontology
             strict: If True (default), fail when term IDs are not found in configured ontologies
             cache_labels: Whether to cache ontology labels to disk
             cache_dir: Directory for label cache files


### PR DESCRIPTION
## Summary

- Label validation (`--labels`) is now enabled by default for `validate-data` command
- This catches AI hallucinations where valid term IDs have incorrect labels - the primary use case for this validator
- Users can disable with `--no-labels` if they only want ID validation

## Changes

- `cli.py`: Changed `validate_labels` default from `False` to `True`
- `binding_plugin.py`: Changed `validate_labels` parameter default from `False` to `True`
- Updated documentation (README.md, docs/binding-validation.md, docs/plugin-reference.md)

## Test plan

- [x] All unit tests pass (58 tests)
- [x] Doctests pass
- [x] mypy type checking passes
- [x] ruff linting passes
- [x] CLI help shows `[default: labels]`

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)