### PR TITLE
Fix cache stability: preserve timestamps and sort entries deterministically

### DIFF
--- a/src/linkml_term_validator/cli.py
+++ b/src/linkml_term_validator/cli.py
@@ -426,6 +426,199 @@ def validate_all(
         )
 
 
+@app.command(name="migrate-cache")
+def migrate_cache(
+    cache_dir: Annotated[
+        Path,
+        typer.Option(
+            "--cache-dir",
+            help="Directory containing cache files",
+        ),
+    ] = Path("cache"),
+    adapter: Annotated[
+        str,
+        typer.Option(
+            "--adapter",
+            "-a",
+            help="OAK adapter string (default: sqlite:obo:)",
+        ),
+    ] = "sqlite:obo:",
+    config: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--config",
+            "-c",
+            help="Path to oak_config.yaml",
+        ),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            help="Show what would change without writing",
+        ),
+    ] = False,
+    refresh_labels: Annotated[
+        bool,
+        typer.Option(
+            "--refresh-labels",
+            help="Re-fetch labels from ontology and update changed ones",
+        ),
+    ] = False,
+    sort_only: Annotated[
+        bool,
+        typer.Option(
+            "--sort-only",
+            help="Only sort and deduplicate cache files without fetching labels",
+        ),
+    ] = False,
+):
+    """Migrate and normalize cache files to eliminate spurious diffs.
+
+    This command normalizes existing cache files by:
+    - Sorting entries by CURIE for deterministic output
+    - Deduplicating entries (keeping the latest timestamp)
+    - Optionally re-fetching labels to update relabelings
+
+    Use this after upgrading linkml-term-validator to normalize existing
+    cache files and prevent spurious diffs in version control.
+
+    Examples:
+        linkml-term-validator migrate-cache
+        linkml-term-validator migrate-cache --refresh-labels
+        linkml-term-validator migrate-cache --dry-run
+        linkml-term-validator migrate-cache --sort-only
+    """
+    import csv
+    from datetime import datetime
+
+    from linkml_term_validator.plugins.base import BaseOntologyPlugin
+
+    if not cache_dir.exists():
+        typer.echo(f"Cache directory not found: {cache_dir}", err=True)
+        raise typer.Exit(code=1)
+
+    # Find all terms.csv files
+    terms_files = sorted(cache_dir.glob("*/terms.csv"))
+    if not terms_files:
+        typer.echo("No cache files found to migrate.")
+        return
+
+    # Create a plugin instance for label lookups if refreshing
+    plugin = None
+    if refresh_labels:
+        plugin = BaseOntologyPlugin(
+            oak_adapter_string=adapter,
+            cache_labels=False,  # Don't write cache during migration
+            cache_dir=cache_dir,
+            oak_config_path=config,
+        )
+
+    total_files = 0
+    total_updated = 0
+    total_relabeled = 0
+    total_removed_dupes = 0
+
+    for terms_file in terms_files:
+        total_files += 1
+
+        # Load existing entries preserving all data
+        entries: dict[str, dict[str, str]] = {}
+        dupes = 0
+        with open(terms_file) as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                curie = row["curie"]
+                if curie in entries:
+                    dupes += 1
+                    # Keep the one with the later timestamp
+                    existing_ts = entries[curie].get("retrieved_at", "")
+                    new_ts = row.get("retrieved_at", "")
+                    if new_ts > existing_ts:
+                        entries[curie] = {
+                            "label": row["label"],
+                            "retrieved_at": new_ts,
+                        }
+                else:
+                    entries[curie] = {
+                        "label": row["label"],
+                        "retrieved_at": row.get("retrieved_at", ""),
+                    }
+
+        total_removed_dupes += dupes
+
+        # Optionally refresh labels from ontology
+        relabeled = 0
+        if refresh_labels and plugin and not sort_only:
+            for curie in list(entries.keys()):
+                old_label = entries[curie]["label"]
+                new_label = plugin.get_ontology_label(curie)
+                if new_label and new_label != old_label:
+                    relabeled += 1
+                    if dry_run:
+                        typer.echo(f"  {curie}: '{old_label}' -> '{new_label}'")
+                    else:
+                        entries[curie] = {
+                            "label": new_label,
+                            "retrieved_at": datetime.now().isoformat(),
+                        }
+
+        total_relabeled += relabeled
+
+        # Check if file needs rewriting (sort order, dupes, relabelings)
+        sorted_curies = sorted(entries.keys())
+        needs_rewrite = dupes > 0 or relabeled > 0
+
+        # Check if already sorted
+        if not needs_rewrite:
+            existing_curies = []
+            with open(terms_file) as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    existing_curies.append(row["curie"])
+            if existing_curies != sorted_curies:
+                needs_rewrite = True
+
+        if needs_rewrite:
+            total_updated += 1
+            status_parts = []
+            if dupes > 0:
+                status_parts.append(f"{dupes} dupes removed")
+            if relabeled > 0:
+                status_parts.append(f"{relabeled} relabeled")
+            if not status_parts:
+                status_parts.append("sorted")
+            status = ", ".join(status_parts)
+
+            if dry_run:
+                typer.echo(f"  Would update {terms_file} ({status})")
+            else:
+                with open(terms_file, "w", newline="") as f:
+                    writer = csv.DictWriter(f, fieldnames=["curie", "label", "retrieved_at"])
+                    writer.writeheader()
+                    for c in sorted_curies:
+                        writer.writerow(
+                            {
+                                "curie": c,
+                                "label": entries[c]["label"],
+                                "retrieved_at": entries[c]["retrieved_at"],
+                            }
+                        )
+                typer.echo(f"  Updated {terms_file} ({status})")
+        else:
+            if dry_run:
+                typer.echo(f"  {terms_file} - no changes needed")
+
+    # Summary
+    typer.echo(f"\nMigration {'preview' if dry_run else 'complete'}:")
+    typer.echo(f"  Files scanned: {total_files}")
+    typer.echo(f"  Files {'needing' if dry_run else 'updated'}: {total_updated}")
+    if total_removed_dupes > 0:
+        typer.echo(f"  Duplicates removed: {total_removed_dupes}")
+    if total_relabeled > 0:
+        typer.echo(f"  Labels updated: {total_relabeled}")
+
+
 def main():
     """Main entry point for the CLI."""
     app()

--- a/src/linkml_term_validator/plugins/base.py
+++ b/src/linkml_term_validator/plugins/base.py
@@ -161,8 +161,35 @@ class BaseOntologyPlugin(ValidationPlugin):
                 cached[row["curie"]] = row["label"]
         return cached
 
+    def _load_cache_with_timestamps(self, prefix: str) -> dict[str, dict[str, str]]:
+        """Load cached labels with timestamps for a prefix.
+
+        Args:
+            prefix: Ontology prefix
+
+        Returns:
+            Dict mapping CURIEs to {"label": ..., "retrieved_at": ...}
+        """
+        cache_file = self._get_cache_file(prefix)
+        if not cache_file.exists():
+            return {}
+
+        cached: dict[str, dict[str, str]] = {}
+        with open(cache_file) as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                cached[row["curie"]] = {
+                    "label": row["label"],
+                    "retrieved_at": row.get("retrieved_at", ""),
+                }
+        return cached
+
     def _save_to_cache(self, prefix: str, curie: str, label: str) -> None:
         """Save a label to the cache.
+
+        Preserves existing timestamps for unchanged entries.
+        Only new or changed entries get a fresh timestamp.
+        Entries are sorted by CURIE for deterministic output.
 
         Args:
             prefix: Ontology prefix
@@ -171,20 +198,24 @@ class BaseOntologyPlugin(ValidationPlugin):
         """
         cache_file = self._get_cache_file(prefix)
 
-        # Load existing cache
-        existing = self._load_cache(prefix)
-        existing[curie] = label
+        # Load existing cache with timestamps preserved
+        existing = self._load_cache_with_timestamps(prefix)
 
-        # Write back
-        with open(cache_file, "w") as f:
+        # Only set new timestamp if entry is new or label changed
+        now = datetime.now().isoformat()
+        if curie not in existing or existing[curie]["label"] != label:
+            existing[curie] = {"label": label, "retrieved_at": now}
+
+        # Write back sorted by curie for deterministic output
+        with open(cache_file, "w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=["curie", "label", "retrieved_at"])
             writer.writeheader()
-            for curie, label in existing.items():
+            for c in sorted(existing.keys()):
                 writer.writerow(
                     {
-                        "curie": curie,
-                        "label": label,
-                        "retrieved_at": datetime.now().isoformat(),
+                        "curie": c,
+                        "label": existing[c]["label"],
+                        "retrieved_at": existing[c]["retrieved_at"],
                     }
                 )
 

--- a/src/linkml_term_validator/validator.py
+++ b/src/linkml_term_validator/validator.py
@@ -142,8 +142,35 @@ class EnumValidator:
                 cached[row["curie"]] = row["label"]
         return cached
 
+    def _load_cache_with_timestamps(self, prefix: str) -> dict[str, dict[str, str]]:
+        """Load cached labels with timestamps for a prefix.
+
+        Args:
+            prefix: Ontology prefix
+
+        Returns:
+            Dict mapping CURIEs to {"label": ..., "retrieved_at": ...}
+        """
+        cache_file = self._get_cache_file(prefix)
+        if not cache_file.exists():
+            return {}
+
+        cached: dict[str, dict[str, str]] = {}
+        with open(cache_file) as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                cached[row["curie"]] = {
+                    "label": row["label"],
+                    "retrieved_at": row.get("retrieved_at", ""),
+                }
+        return cached
+
     def _save_to_cache(self, prefix: str, curie: str, label: str) -> None:
         """Save a label to the cache.
+
+        Preserves existing timestamps for unchanged entries.
+        Only new or changed entries get a fresh timestamp.
+        Entries are sorted by CURIE for deterministic output.
 
         Args:
             prefix: Ontology prefix
@@ -154,19 +181,27 @@ class EnumValidator:
             return
 
         cache_file = self._get_cache_file(prefix)
-        file_exists = cache_file.exists()
 
-        with open(cache_file, "a", newline="") as f:
+        # Load existing cache with timestamps preserved
+        existing = self._load_cache_with_timestamps(prefix)
+
+        # Only set new timestamp if entry is new or label changed
+        now = datetime.now().isoformat()
+        if curie not in existing or existing[curie]["label"] != label:
+            existing[curie] = {"label": label, "retrieved_at": now}
+
+        # Write back sorted by curie for deterministic output
+        with open(cache_file, "w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=["curie", "label", "retrieved_at"])
-            if not file_exists:
-                writer.writeheader()
-            writer.writerow(
-                {
-                    "curie": curie,
-                    "label": label,
-                    "retrieved_at": datetime.now().isoformat(),
-                }
-            )
+            writer.writeheader()
+            for c in sorted(existing.keys()):
+                writer.writerow(
+                    {
+                        "curie": c,
+                        "label": existing[c]["label"],
+                        "retrieved_at": existing[c]["retrieved_at"],
+                    }
+                )
 
     def _get_adapter(self, prefix: str) -> object | None:
         """Get an OAK adapter for a prefix.

--- a/tests/test_cache_stability.py
+++ b/tests/test_cache_stability.py
@@ -1,0 +1,213 @@
+"""Tests for cache stability - verifying no spurious diffs."""
+
+import csv
+from pathlib import Path
+
+import pytest
+
+from linkml_term_validator.models import ValidationConfig
+from linkml_term_validator.plugins import PermissibleValueMeaningPlugin
+from linkml_term_validator.validator import EnumValidator
+
+
+@pytest.fixture
+def cache_dir(tmp_path):
+    """Create a temporary cache directory."""
+    d = tmp_path / "cache"
+    d.mkdir()
+    return d
+
+
+def _write_terms_csv(cache_file: Path, entries: list[dict[str, str]]) -> None:
+    """Helper to write a terms.csv file."""
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(cache_file, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["curie", "label", "retrieved_at"])
+        writer.writeheader()
+        for entry in entries:
+            writer.writerow(entry)
+
+
+def _read_terms_csv(cache_file: Path) -> list[dict[str, str]]:
+    """Helper to read a terms.csv file."""
+    rows = []
+    with open(cache_file) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            rows.append(dict(row))
+    return rows
+
+
+class TestBasePluginCacheStability:
+    """Tests for BaseOntologyPlugin cache stability."""
+
+    def test_save_preserves_existing_timestamps(self, cache_dir):
+        """Adding a new term should NOT change timestamps of existing terms."""
+        prefix_dir = cache_dir / "go"
+        prefix_dir.mkdir()
+        cache_file = prefix_dir / "terms.csv"
+
+        # Pre-populate cache with known timestamps
+        original_ts = "2025-01-15T10:00:00.000000"
+        _write_terms_csv(cache_file, [
+            {"curie": "GO:0008150", "label": "biological_process", "retrieved_at": original_ts},
+            {"curie": "GO:0003674", "label": "molecular_function", "retrieved_at": original_ts},
+        ])
+
+        # Create plugin and save a new entry
+        plugin = PermissibleValueMeaningPlugin(cache_labels=True, cache_dir=cache_dir)
+        plugin._save_to_cache("GO", "GO:0005575", "cellular_component")
+
+        # Read back and verify
+        rows = _read_terms_csv(cache_file)
+        by_curie = {r["curie"]: r for r in rows}
+
+        # Existing entries should keep their original timestamps
+        assert by_curie["GO:0008150"]["retrieved_at"] == original_ts
+        assert by_curie["GO:0003674"]["retrieved_at"] == original_ts
+        # New entry should have a fresh timestamp
+        assert by_curie["GO:0005575"]["retrieved_at"] != original_ts
+        assert by_curie["GO:0005575"]["label"] == "cellular_component"
+
+    def test_save_sorts_by_curie(self, cache_dir):
+        """Cache entries should be sorted by CURIE for deterministic output."""
+        prefix_dir = cache_dir / "go"
+        prefix_dir.mkdir()
+        cache_file = prefix_dir / "terms.csv"
+
+        # Pre-populate in unsorted order
+        _write_terms_csv(cache_file, [
+            {"curie": "GO:0005575", "label": "cellular_component", "retrieved_at": "2025-01-01"},
+            {"curie": "GO:0003674", "label": "molecular_function", "retrieved_at": "2025-01-01"},
+            {"curie": "GO:0008150", "label": "biological_process", "retrieved_at": "2025-01-01"},
+        ])
+
+        # Save triggers a rewrite
+        plugin = PermissibleValueMeaningPlugin(cache_labels=True, cache_dir=cache_dir)
+        plugin._save_to_cache("GO", "GO:0009987", "cellular process")
+
+        rows = _read_terms_csv(cache_file)
+        curies = [r["curie"] for r in rows]
+        assert curies == sorted(curies)
+
+    def test_save_same_label_no_timestamp_change(self, cache_dir):
+        """Re-saving the same curie+label should not change the timestamp."""
+        prefix_dir = cache_dir / "go"
+        prefix_dir.mkdir()
+        cache_file = prefix_dir / "terms.csv"
+
+        original_ts = "2025-01-15T10:00:00.000000"
+        _write_terms_csv(cache_file, [
+            {"curie": "GO:0008150", "label": "biological_process", "retrieved_at": original_ts},
+        ])
+
+        plugin = PermissibleValueMeaningPlugin(cache_labels=True, cache_dir=cache_dir)
+        plugin._save_to_cache("GO", "GO:0008150", "biological_process")
+
+        rows = _read_terms_csv(cache_file)
+        assert rows[0]["retrieved_at"] == original_ts
+
+    def test_save_changed_label_updates_timestamp(self, cache_dir):
+        """Saving with a different label should update the timestamp."""
+        prefix_dir = cache_dir / "go"
+        prefix_dir.mkdir()
+        cache_file = prefix_dir / "terms.csv"
+
+        original_ts = "2025-01-15T10:00:00.000000"
+        _write_terms_csv(cache_file, [
+            {"curie": "GO:0008150", "label": "biological_process", "retrieved_at": original_ts},
+        ])
+
+        plugin = PermissibleValueMeaningPlugin(cache_labels=True, cache_dir=cache_dir)
+        plugin._save_to_cache("GO", "GO:0008150", "biological process")
+
+        rows = _read_terms_csv(cache_file)
+        assert rows[0]["label"] == "biological process"
+        assert rows[0]["retrieved_at"] != original_ts
+
+    def test_idempotent_save(self, cache_dir):
+        """Multiple saves of the same data should produce identical files."""
+        prefix_dir = cache_dir / "go"
+        prefix_dir.mkdir()
+        cache_file = prefix_dir / "terms.csv"
+
+        original_ts = "2025-01-15T10:00:00.000000"
+        entries = [
+            {"curie": "GO:0003674", "label": "molecular_function", "retrieved_at": original_ts},
+            {"curie": "GO:0005575", "label": "cellular_component", "retrieved_at": original_ts},
+            {"curie": "GO:0008150", "label": "biological_process", "retrieved_at": original_ts},
+        ]
+        _write_terms_csv(cache_file, entries)
+
+        content_before = cache_file.read_text()
+
+        # Save an existing entry with the same label
+        plugin = PermissibleValueMeaningPlugin(cache_labels=True, cache_dir=cache_dir)
+        plugin._save_to_cache("GO", "GO:0008150", "biological_process")
+
+        content_after = cache_file.read_text()
+        assert content_before == content_after
+
+
+class TestValidatorCacheStability:
+    """Tests for EnumValidator cache stability."""
+
+    def test_save_preserves_existing_timestamps(self, cache_dir):
+        """Adding a new term should NOT change timestamps of existing terms."""
+        prefix_dir = cache_dir / "go"
+        prefix_dir.mkdir()
+        cache_file = prefix_dir / "terms.csv"
+
+        original_ts = "2025-01-15T10:00:00.000000"
+        _write_terms_csv(cache_file, [
+            {"curie": "GO:0008150", "label": "biological_process", "retrieved_at": original_ts},
+        ])
+
+        config = ValidationConfig(cache_labels=True, cache_dir=cache_dir)
+        validator = EnumValidator(config)
+        validator._save_to_cache("GO", "GO:0003674", "molecular_function")
+
+        rows = _read_terms_csv(cache_file)
+        by_curie = {r["curie"]: r for r in rows}
+
+        assert by_curie["GO:0008150"]["retrieved_at"] == original_ts
+        assert by_curie["GO:0003674"]["retrieved_at"] != original_ts
+
+    def test_save_sorts_by_curie(self, cache_dir):
+        """Cache entries should be sorted by CURIE."""
+        prefix_dir = cache_dir / "go"
+        prefix_dir.mkdir()
+        cache_file = prefix_dir / "terms.csv"
+
+        _write_terms_csv(cache_file, [
+            {"curie": "GO:0008150", "label": "biological_process", "retrieved_at": "2025-01-01"},
+            {"curie": "GO:0003674", "label": "molecular_function", "retrieved_at": "2025-01-01"},
+        ])
+
+        config = ValidationConfig(cache_labels=True, cache_dir=cache_dir)
+        validator = EnumValidator(config)
+        validator._save_to_cache("GO", "GO:0005575", "cellular_component")
+
+        rows = _read_terms_csv(cache_file)
+        curies = [r["curie"] for r in rows]
+        assert curies == sorted(curies)
+
+    def test_idempotent_save(self, cache_dir):
+        """Re-saving same label should produce identical file."""
+        prefix_dir = cache_dir / "go"
+        prefix_dir.mkdir()
+        cache_file = prefix_dir / "terms.csv"
+
+        original_ts = "2025-01-15T10:00:00.000000"
+        _write_terms_csv(cache_file, [
+            {"curie": "GO:0008150", "label": "biological_process", "retrieved_at": original_ts},
+        ])
+
+        content_before = cache_file.read_text()
+
+        config = ValidationConfig(cache_labels=True, cache_dir=cache_dir)
+        validator = EnumValidator(config)
+        validator._save_to_cache("GO", "GO:0008150", "biological_process")
+
+        content_after = cache_file.read_text()
+        assert content_before == content_after

--- a/tests/test_migrate_cache.py
+++ b/tests/test_migrate_cache.py
@@ -1,0 +1,128 @@
+"""Tests for the migrate-cache CLI command."""
+
+import csv
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from linkml_term_validator.cli import app
+
+runner = CliRunner()
+
+
+def _write_terms_csv(cache_file: Path, entries: list[dict[str, str]]) -> None:
+    """Helper to write a terms.csv file."""
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(cache_file, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["curie", "label", "retrieved_at"])
+        writer.writeheader()
+        for entry in entries:
+            writer.writerow(entry)
+
+
+def _read_terms_csv(cache_file: Path) -> list[dict[str, str]]:
+    """Helper to read a terms.csv file."""
+    rows = []
+    with open(cache_file) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            rows.append(dict(row))
+    return rows
+
+
+def test_migrate_sorts_entries(tmp_path):
+    """migrate-cache should sort entries by CURIE."""
+    cache_dir = tmp_path / "cache"
+    terms_file = cache_dir / "go" / "terms.csv"
+    _write_terms_csv(terms_file, [
+        {"curie": "GO:0008150", "label": "biological_process", "retrieved_at": "2025-01-01"},
+        {"curie": "GO:0003674", "label": "molecular_function", "retrieved_at": "2025-01-01"},
+        {"curie": "GO:0005575", "label": "cellular_component", "retrieved_at": "2025-01-01"},
+    ])
+
+    result = runner.invoke(app, ["migrate-cache", "--cache-dir", str(cache_dir)])
+    assert result.exit_code == 0
+
+    rows = _read_terms_csv(terms_file)
+    curies = [r["curie"] for r in rows]
+    assert curies == sorted(curies)
+
+
+def test_migrate_preserves_timestamps(tmp_path):
+    """migrate-cache should preserve existing timestamps."""
+    cache_dir = tmp_path / "cache"
+    terms_file = cache_dir / "go" / "terms.csv"
+    ts = "2025-01-15T10:00:00.000000"
+    _write_terms_csv(terms_file, [
+        {"curie": "GO:0003674", "label": "molecular_function", "retrieved_at": ts},
+        {"curie": "GO:0008150", "label": "biological_process", "retrieved_at": ts},
+    ])
+
+    result = runner.invoke(app, ["migrate-cache", "--cache-dir", str(cache_dir)])
+    assert result.exit_code == 0
+
+    rows = _read_terms_csv(terms_file)
+    for row in rows:
+        assert row["retrieved_at"] == ts
+
+
+def test_migrate_removes_duplicates(tmp_path):
+    """migrate-cache should deduplicate entries, keeping latest timestamp."""
+    cache_dir = tmp_path / "cache"
+    terms_file = cache_dir / "go" / "terms.csv"
+    _write_terms_csv(terms_file, [
+        {"curie": "GO:0008150", "label": "biological_process", "retrieved_at": "2025-01-01"},
+        {"curie": "GO:0008150", "label": "biological_process", "retrieved_at": "2025-06-01"},
+        {"curie": "GO:0003674", "label": "molecular_function", "retrieved_at": "2025-01-01"},
+    ])
+
+    result = runner.invoke(app, ["migrate-cache", "--cache-dir", str(cache_dir)])
+    assert result.exit_code == 0
+    assert "dupes removed" in result.output
+
+    rows = _read_terms_csv(terms_file)
+    assert len(rows) == 2
+    by_curie = {r["curie"]: r for r in rows}
+    assert by_curie["GO:0008150"]["retrieved_at"] == "2025-06-01"
+
+
+def test_migrate_dry_run(tmp_path):
+    """--dry-run should not modify files."""
+    cache_dir = tmp_path / "cache"
+    terms_file = cache_dir / "go" / "terms.csv"
+    _write_terms_csv(terms_file, [
+        {"curie": "GO:0008150", "label": "biological_process", "retrieved_at": "2025-01-01"},
+        {"curie": "GO:0003674", "label": "molecular_function", "retrieved_at": "2025-01-01"},
+    ])
+
+    content_before = terms_file.read_text()
+    result = runner.invoke(app, ["migrate-cache", "--cache-dir", str(cache_dir), "--dry-run"])
+    assert result.exit_code == 0
+    assert "preview" in result.output
+
+    content_after = terms_file.read_text()
+    assert content_before == content_after
+
+
+def test_migrate_no_cache_dir(tmp_path):
+    """Should fail gracefully if cache dir doesn't exist."""
+    result = runner.invoke(app, ["migrate-cache", "--cache-dir", str(tmp_path / "nonexistent")])
+    assert result.exit_code == 1
+
+
+def test_migrate_already_sorted(tmp_path):
+    """Already-sorted file should report no changes needed."""
+    cache_dir = tmp_path / "cache"
+    terms_file = cache_dir / "go" / "terms.csv"
+    _write_terms_csv(terms_file, [
+        {"curie": "GO:0003674", "label": "molecular_function", "retrieved_at": "2025-01-01"},
+        {"curie": "GO:0008150", "label": "biological_process", "retrieved_at": "2025-01-01"},
+    ])
+
+    content_before = terms_file.read_text()
+    result = runner.invoke(app, ["migrate-cache", "--cache-dir", str(cache_dir)])
+    assert result.exit_code == 0
+    assert "Files updated: 0" in result.output or "Files needing: 0" in result.output
+
+    content_after = terms_file.read_text()
+    assert content_before == content_after


### PR DESCRIPTION
## Summary

This PR fixes cache stability issues that cause spurious diffs in version control when cache files are updated. The changes ensure that cache files are written deterministically by sorting entries by CURIE and preserving timestamps for unchanged entries.

## Key Changes

- **Preserve timestamps for unchanged entries**: Modified `_save_to_cache()` in both `BaseOntologyPlugin` and `EnumValidator` to only update timestamps when an entry is new or its label has changed. Existing entries keep their original `retrieved_at` values.

- **Deterministic cache output**: Cache entries are now sorted by CURIE before writing, ensuring consistent file ordering across runs and preventing spurious diffs.

- **New `_load_cache_with_timestamps()` method**: Added to both plugin and validator classes to load cache entries while preserving timestamp metadata, enabling intelligent timestamp management during saves.

- **New `migrate-cache` CLI command**: Provides a utility to normalize existing cache files by:
  - Sorting entries by CURIE
  - Deduplicating entries (keeping the latest timestamp)
  - Optionally re-fetching labels from ontologies with `--refresh-labels`
  - Supporting `--dry-run` mode to preview changes without writing
  - Supporting `--sort-only` mode to skip label refreshing

- **Comprehensive test coverage**: Added `test_cache_stability.py` with tests for both plugin and validator cache behavior, and `test_migrate_cache.py` with CLI command tests.

## Implementation Details

- Cache files are now written atomically by loading all entries, updating only what changed, and writing back the complete sorted set
- The migration command handles deduplication by keeping entries with the latest timestamp when duplicates are found
- All timestamp preservation logic is idempotent: re-saving identical data produces identical files

https://claude.ai/code/session_01T5Lx5JS984FrieGu6DSVPo