### PR TITLE
Experiment: CPT code validation from CMS data

### DIFF
--- a/src/linkml_term_validator/cpt_utils.py
+++ b/src/linkml_term_validator/cpt_utils.py
@@ -122,11 +122,17 @@ def parse_rvu_csv(csv_content: str) -> dict[str, str]:
     try:
         lines = csv_content.splitlines()
 
-        # Skip the 10 header rows
-        if len(lines) <= 10:
-            raise CptParseError("CSV has fewer than 10 lines — missing data rows")
+        # Find the header row (starts with "HCPCS,")
+        header_idx = None
+        for i, line in enumerate(lines):
+            if line.startswith("HCPCS,"):
+                header_idx = i
+                break
 
-        data_lines = lines[10:]
+        if header_idx is None:
+            raise CptParseError("Could not find HCPCS header row in CSV")
+
+        data_lines = lines[header_idx:]
         reader = csv.DictReader(data_lines)
 
         codes: dict[str, str] = {}

--- a/src/linkml_term_validator/cpt_utils.py
+++ b/src/linkml_term_validator/cpt_utils.py
@@ -1,0 +1,201 @@
+"""Utilities for building CPT code validation cache from CMS data.
+
+Downloads the CMS Physician Fee Schedule Relative Value Files (RVU),
+extracts CPT codes and short descriptors, and writes a cache file
+compatible with the existing label cache format.
+
+No new dependencies — uses only stdlib (urllib, zipfile, csv, io, re).
+"""
+
+import csv
+import io
+import os
+import re
+import sys
+import zipfile
+from datetime import datetime
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+CMS_RVU_URL = "https://www.cms.gov/files/zip/rvu26a-updated-12-29-2025.zip"
+
+# Matches CPT Category I (99213), Category II (0001F), Category III (0054T)
+# Excludes HCPCS Level II codes (alpha prefix like G0101)
+CPT_CODE_PATTERN = re.compile(r"^\d{4}[0-9FT]$")
+
+# Finds the RVU CSV inside the ZIP archive
+RVU_CSV_PATTERN = re.compile(r"PPRRVU.*nonQP.*\.csv", re.IGNORECASE)
+
+
+class CptDataError(Exception):
+    """Base exception for CPT data errors."""
+
+
+class CptDownloadError(CptDataError):
+    """Error downloading CPT data from CMS."""
+
+
+class CptParseError(CptDataError):
+    """Error parsing CPT data."""
+
+
+def is_cpt_prefix(prefix: str) -> bool:
+    """Check if a prefix refers to CPT codes (case-insensitive).
+
+    Args:
+        prefix: Ontology prefix string
+
+    Returns:
+        True if this is a CPT prefix
+    """
+    return prefix.upper() == "CPT"
+
+
+def download_rvu_zip(url: str | None = None) -> bytes:
+    """Download the CMS RVU ZIP file.
+
+    Args:
+        url: URL to download from (defaults to CMS_RVU_URL or env var override)
+
+    Returns:
+        Raw bytes of the ZIP file
+
+    Raises:
+        CptDownloadError: If download fails
+    """
+    if url is None:
+        url = os.environ.get("LINKML_TERM_VALIDATOR_CPT_URL", CMS_RVU_URL)
+
+    print(f"Downloading CPT data from {url} ...", file=sys.stderr)
+
+    try:
+        req = Request(url, headers={"User-Agent": "linkml-term-validator"})
+        with urlopen(req, timeout=120) as response:  # noqa: S310
+            data = response.read()
+        print(f"Downloaded {len(data)} bytes.", file=sys.stderr)
+        return data
+    except Exception as e:
+        raise CptDownloadError(f"Failed to download CPT data from {url}: {e}") from e
+
+
+def find_rvu_csv_in_zip(zip_data: bytes) -> str:
+    """Extract the RVU CSV content from a ZIP archive.
+
+    Args:
+        zip_data: Raw bytes of the ZIP file
+
+    Returns:
+        CSV content as a string
+
+    Raises:
+        CptParseError: If the expected CSV file is not found in the ZIP
+    """
+    try:
+        with zipfile.ZipFile(io.BytesIO(zip_data)) as zf:
+            for name in zf.namelist():
+                if RVU_CSV_PATTERN.search(name):
+                    return zf.read(name).decode("utf-8", errors="replace")
+            raise CptParseError(
+                f"No RVU CSV found in ZIP. Files: {zf.namelist()}"
+            )
+    except zipfile.BadZipFile as e:
+        raise CptParseError(f"Invalid ZIP file: {e}") from e
+
+
+def parse_rvu_csv(csv_content: str) -> dict[str, str]:
+    """Parse the RVU CSV and extract base CPT codes with labels.
+
+    The CMS RVU CSV has 10 header/comment rows before the actual data.
+    We extract rows where:
+    - MOD column is empty (base codes only, no modifiers)
+    - HCPCS code matches CPT pattern (digits + digit/F/T suffix)
+
+    Args:
+        csv_content: Raw CSV content string
+
+    Returns:
+        Dict mapping CPT codes to short descriptors (e.g. {"99213": "Office o/p est low 20 min"})
+
+    Raises:
+        CptParseError: If CSV cannot be parsed
+    """
+    try:
+        lines = csv_content.splitlines()
+
+        # Skip the 10 header rows
+        if len(lines) <= 10:
+            raise CptParseError("CSV has fewer than 10 lines — missing data rows")
+
+        data_lines = lines[10:]
+        reader = csv.DictReader(data_lines)
+
+        codes: dict[str, str] = {}
+        for row in reader:
+            hcpcs = row.get("HCPCS", "").strip()
+            mod = row.get("MOD", "").strip()
+            description = row.get("DESCRIPTION", "").strip()
+
+            # Skip rows with modifiers (we want base codes only)
+            if mod:
+                continue
+
+            # Only include codes matching CPT patterns
+            if CPT_CODE_PATTERN.match(hcpcs) and description:
+                codes[hcpcs] = description
+
+        if not codes:
+            raise CptParseError("No CPT codes found in CSV data")
+
+        return codes
+
+    except CptParseError:
+        raise
+    except Exception as e:
+        raise CptParseError(f"Failed to parse RVU CSV: {e}") from e
+
+
+def build_cpt_cache(cache_dir: Path | str, url: str | None = None) -> Path:
+    """Download CMS data and build the CPT label cache.
+
+    This is the main entry point. It:
+    1. Downloads the RVU ZIP from CMS
+    2. Extracts and parses the CSV
+    3. Writes cache/cpt/terms.csv in the standard cache format
+
+    Args:
+        cache_dir: Root cache directory (e.g. Path("cache"))
+        url: Optional URL override for testing
+
+    Returns:
+        Path to the written cache file
+
+    Raises:
+        CptDataError: If download or parsing fails
+    """
+    cache_dir = Path(cache_dir)
+
+    zip_data = download_rvu_zip(url)
+    csv_content = find_rvu_csv_in_zip(zip_data)
+    codes = parse_rvu_csv(csv_content)
+
+    # Write cache file
+    cpt_dir = cache_dir / "cpt"
+    cpt_dir.mkdir(parents=True, exist_ok=True)
+    cache_file = cpt_dir / "terms.csv"
+
+    now = datetime.now().isoformat()
+
+    with open(cache_file, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["curie", "label", "retrieved_at"])
+        writer.writeheader()
+        for code in sorted(codes.keys()):
+            writer.writerow(
+                {
+                    "curie": f"CPT:{code}",
+                    "label": codes[code],
+                    "retrieved_at": now,
+                }
+            )
+
+    print(f"CPT cache built: {len(codes)} codes written to {cache_file}", file=sys.stderr)
+    return cache_file

--- a/src/linkml_term_validator/plugins/base.py
+++ b/src/linkml_term_validator/plugins/base.py
@@ -17,6 +17,7 @@ Example:
 import csv
 import hashlib
 import re
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal, Optional
@@ -152,7 +153,12 @@ class BaseOntologyPlugin(ValidationPlugin):
         """
         cache_file = self._get_cache_file(prefix)
         if not cache_file.exists():
-            return {}
+            if _should_auto_build_cache(prefix):
+                _auto_build_cache(prefix, self.config.cache_dir)
+                if not cache_file.exists():
+                    return {}
+            else:
+                return {}
 
         cached = {}
         with open(cache_file) as f:
@@ -816,3 +822,21 @@ class BaseOntologyPlugin(ValidationPlugin):
         # This would require querying the ontology for all terms matching a pattern
         # For now, return empty set - this is a more advanced feature
         return set()
+
+
+def _should_auto_build_cache(prefix: str) -> bool:
+    """Check if a prefix supports automatic cache building."""
+    from linkml_term_validator.cpt_utils import is_cpt_prefix
+
+    return is_cpt_prefix(prefix)
+
+
+def _auto_build_cache(prefix: str, cache_dir: Path) -> None:
+    """Attempt to auto-build a cache for the given prefix."""
+    from linkml_term_validator.cpt_utils import CptDataError, build_cpt_cache, is_cpt_prefix
+
+    if is_cpt_prefix(prefix):
+        try:
+            build_cpt_cache(cache_dir)
+        except CptDataError as e:
+            print(f"Warning: Could not auto-build CPT cache: {e}", file=sys.stderr)

--- a/src/linkml_term_validator/validator.py
+++ b/src/linkml_term_validator/validator.py
@@ -2,6 +2,7 @@
 
 import csv
 import re
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -133,7 +134,12 @@ class EnumValidator:
         """
         cache_file = self._get_cache_file(prefix)
         if not cache_file.exists():
-            return {}
+            if _should_auto_build_cache(prefix):
+                _auto_build_cache(prefix, self.config.cache_dir)
+                if not cache_file.exists():
+                    return {}
+            else:
+                return {}
 
         cached = {}
         with open(cache_file) as f:
@@ -491,3 +497,21 @@ class EnumValidator:
             set()
         """
         return self._unknown_prefixes
+
+
+def _should_auto_build_cache(prefix: str) -> bool:
+    """Check if a prefix supports automatic cache building."""
+    from linkml_term_validator.cpt_utils import is_cpt_prefix
+
+    return is_cpt_prefix(prefix)
+
+
+def _auto_build_cache(prefix: str, cache_dir: Path) -> None:
+    """Attempt to auto-build a cache for the given prefix."""
+    from linkml_term_validator.cpt_utils import CptDataError, build_cpt_cache, is_cpt_prefix
+
+    if is_cpt_prefix(prefix):
+        try:
+            build_cpt_cache(cache_dir)
+        except CptDataError as e:
+            print(f"Warning: Could not auto-build CPT cache: {e}", file=sys.stderr)

--- a/tests/data/sample_rvu_data.csv
+++ b/tests/data/sample_rvu_data.csv
@@ -1,0 +1,18 @@
+CY 2026 JANUARY PHYSICIAN FEE SCHEDULE RELATIVE VALUE FILE
+This file contains the CY 2026 January Relative Value Units
+for all HCPCS codes.
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+The file is updated periodically to reflect any changes.
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+HCPCS,MOD,DESCRIPTION,STATUS_CODE,NOT_USED_FOR_MEDICARE_PAYMENT,WORK_RVU,NON_FAC_PE_RVU,NON_FAC_NA_INDICATOR,FAC_PE_RVU,FAC_NA_INDICATOR,MP_RVU,NON_FAC_TOTAL,FAC_TOTAL,PCTC_IND,GLOB_DAYS,PRE_OP,INTRA_OP,POST_OP,MULT_PROC,BILAT_SURG,ASST_SURG,CO_SURG,TEAM_SURG,ENDO_BASE,CONV_FACTOR,PHYSICIAN_SUPERVISION,CALC_FLAG,DIAGNOSTIC_IMAGING,NON_FAC_PE_USED,FAC_PE_USED
+99213,,Office o/p est low 20 min,A,,1.30,1.59,,0.83,,0.07,2.96,2.20,0,XXX,0.00,0.00,0.00,0,1,0,0,0,,37.8875,09,,A,,
+99213,25,Office o/p est low 20 min,A,,1.30,1.59,,0.83,,0.07,2.96,2.20,0,XXX,0.00,0.00,0.00,0,1,0,0,0,,37.8875,09,,A,,
+99214,,Office o/p est mod 30 min,A,,1.92,2.41,,1.27,,0.10,4.43,3.29,0,XXX,0.00,0.00,0.00,0,1,0,0,0,,37.8875,09,,A,,
+0001F,,Heart failure composite,A,,0.00,0.04,,0.04,,0.00,0.04,0.04,0,XXX,0.00,0.00,0.00,0,0,0,0,0,,37.8875,09,,N,,
+0054T,,Bone integrity ultrasound,A,,0.00,1.30,,0.30,,0.02,1.32,0.32,0,XXX,0.00,0.00,0.00,0,0,0,0,0,,37.8875,09,,A,,
+G0101,,Ca screen pelvic/breast exam,A,,0.45,0.81,,0.32,,0.03,1.29,0.80,0,XXX,0.00,0.00,0.00,0,0,0,0,0,,37.8875,09,,N,,
+G0102,,Prostate ca screening DRE,A,,0.17,0.50,,0.12,,0.01,0.68,0.30,0,XXX,0.00,0.00,0.00,0,0,0,0,0,,37.8875,09,,N,,

--- a/tests/test_cpt_cache_hook.py
+++ b/tests/test_cpt_cache_hook.py
@@ -1,0 +1,184 @@
+"""Tests for CPT auto-build hooks in _load_cache (base.py and validator.py)."""
+
+import csv
+from pathlib import Path
+
+import pytest
+
+from linkml_term_validator.models import ValidationConfig
+from linkml_term_validator.plugins.permissible_value_plugin import PermissibleValueMeaningPlugin
+from linkml_term_validator.validator import EnumValidator
+
+
+def _write_cpt_cache(cache_dir: Path, entries: dict[str, str]) -> None:
+    """Helper: write a CPT cache file with the given code->label entries."""
+    cpt_dir = cache_dir / "cpt"
+    cpt_dir.mkdir(parents=True, exist_ok=True)
+    cache_file = cpt_dir / "terms.csv"
+    with open(cache_file, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["curie", "label", "retrieved_at"])
+        writer.writeheader()
+        for code, label in sorted(entries.items()):
+            writer.writerow(
+                {"curie": f"CPT:{code}", "label": label, "retrieved_at": "2026-01-01T00:00:00"}
+            )
+
+
+# ── BaseOntologyPlugin._load_cache hook (via concrete PermissibleValueMeaningPlugin) ──
+
+
+def test_base_load_cache_triggers_cpt_build(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """When CPT cache is missing, _load_cache should trigger auto-build."""
+    build_called = {"count": 0}
+
+    def mock_build(cache_dir, url=None):
+        build_called["count"] += 1
+        _write_cpt_cache(cache_dir, {"99213": "Office o/p est low 20 min"})
+        return cache_dir / "cpt" / "terms.csv"
+
+    monkeypatch.setattr("linkml_term_validator.cpt_utils.build_cpt_cache", mock_build)
+
+    plugin = PermissibleValueMeaningPlugin(cache_dir=tmp_path)
+    result = plugin._load_cache("CPT")
+
+    assert build_called["count"] == 1
+    assert "CPT:99213" in result
+    assert result["CPT:99213"] == "Office o/p est low 20 min"
+
+
+def test_base_load_cache_skips_build_when_cache_exists(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """When CPT cache already exists, auto-build should not be triggered."""
+    _write_cpt_cache(tmp_path, {"99213": "Office o/p est low 20 min"})
+
+    build_called = {"count": 0}
+
+    def mock_build(cache_dir, url=None):
+        build_called["count"] += 1
+
+    monkeypatch.setattr("linkml_term_validator.cpt_utils.build_cpt_cache", mock_build)
+
+    plugin = PermissibleValueMeaningPlugin(cache_dir=tmp_path)
+    result = plugin._load_cache("CPT")
+
+    assert build_called["count"] == 0
+    assert "CPT:99213" in result
+
+
+def test_base_load_cache_does_not_trigger_for_non_cpt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Non-CPT prefixes should not trigger auto-build."""
+    build_called = {"count": 0}
+
+    def mock_build(cache_dir, url=None):
+        build_called["count"] += 1
+
+    monkeypatch.setattr("linkml_term_validator.cpt_utils.build_cpt_cache", mock_build)
+
+    plugin = PermissibleValueMeaningPlugin(cache_dir=tmp_path)
+    result = plugin._load_cache("GO")
+
+    assert build_called["count"] == 0
+    assert result == {}
+
+
+def test_base_cpt_auto_build_failure_graceful(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys):
+    """Download failure should print warning, not crash."""
+    from linkml_term_validator.cpt_utils import CptDownloadError
+
+    def mock_build(cache_dir, url=None):
+        raise CptDownloadError("Network unavailable")
+
+    monkeypatch.setattr("linkml_term_validator.cpt_utils.build_cpt_cache", mock_build)
+
+    plugin = PermissibleValueMeaningPlugin(cache_dir=tmp_path)
+    result = plugin._load_cache("CPT")
+
+    assert result == {}
+    captured = capsys.readouterr()
+    assert "Warning" in captured.err
+    assert "CPT" in captured.err
+
+
+# ── EnumValidator._load_cache hook ──
+
+
+def test_validator_load_cache_triggers_cpt_build(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """EnumValidator._load_cache should trigger auto-build for CPT."""
+    def mock_build(cache_dir, url=None):
+        _write_cpt_cache(cache_dir, {"99214": "Office o/p est mod 30 min"})
+        return cache_dir / "cpt" / "terms.csv"
+
+    monkeypatch.setattr("linkml_term_validator.cpt_utils.build_cpt_cache", mock_build)
+
+    config = ValidationConfig(cache_dir=tmp_path)
+    validator = EnumValidator(config)
+    result = validator._load_cache("CPT")
+
+    assert "CPT:99214" in result
+    assert result["CPT:99214"] == "Office o/p est mod 30 min"
+
+
+def test_validator_load_cache_does_not_trigger_for_non_cpt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """EnumValidator should not trigger auto-build for non-CPT prefixes."""
+    build_called = {"count": 0}
+
+    def mock_build(cache_dir, url=None):
+        build_called["count"] += 1
+
+    monkeypatch.setattr("linkml_term_validator.cpt_utils.build_cpt_cache", mock_build)
+
+    config = ValidationConfig(cache_dir=tmp_path)
+    validator = EnumValidator(config)
+    result = validator._load_cache("HP")
+
+    assert build_called["count"] == 0
+    assert result == {}
+
+
+def test_validator_cpt_auto_build_failure_graceful(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys):
+    """EnumValidator should handle CPT build failure gracefully."""
+    from linkml_term_validator.cpt_utils import CptDownloadError
+
+    def mock_build(cache_dir, url=None):
+        raise CptDownloadError("Timeout")
+
+    monkeypatch.setattr("linkml_term_validator.cpt_utils.build_cpt_cache", mock_build)
+
+    config = ValidationConfig(cache_dir=tmp_path)
+    validator = EnumValidator(config)
+    result = validator._load_cache("CPT")
+
+    assert result == {}
+    captured = capsys.readouterr()
+    assert "Warning" in captured.err
+
+
+# ── Label lookup end-to-end (with pre-populated cache) ──
+
+
+def test_cpt_label_lookup_from_cache(tmp_path: Path):
+    """Pre-populated CPT cache should provide labels via get_ontology_label."""
+    _write_cpt_cache(
+        tmp_path,
+        {
+            "99213": "Office o/p est low 20 min",
+            "0001F": "Heart failure composite",
+        },
+    )
+
+    config = ValidationConfig(cache_dir=tmp_path, cache_labels=True)
+    validator = EnumValidator(config)
+
+    assert validator.get_ontology_label("CPT:99213") == "Office o/p est low 20 min"
+    assert validator.get_ontology_label("CPT:0001F") == "Heart failure composite"
+    assert validator.get_ontology_label("CPT:00000") is None  # not in cache
+
+
+def test_cpt_label_lookup_base_plugin(tmp_path: Path):
+    """Pre-populated CPT cache should provide labels via plugin."""
+    _write_cpt_cache(
+        tmp_path,
+        {"99213": "Office o/p est low 20 min"},
+    )
+
+    plugin = PermissibleValueMeaningPlugin(cache_dir=tmp_path)
+    assert plugin.get_ontology_label("CPT:99213") == "Office o/p est low 20 min"

--- a/tests/test_cpt_utils.py
+++ b/tests/test_cpt_utils.py
@@ -1,0 +1,199 @@
+"""Unit tests for CPT utilities (offline, no network calls)."""
+
+import csv
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from linkml_term_validator.cpt_utils import (
+    CPT_CODE_PATTERN,
+    build_cpt_cache,
+    find_rvu_csv_in_zip,
+    is_cpt_prefix,
+    parse_rvu_csv,
+)
+
+SAMPLE_RVU_PATH = Path(__file__).parent / "data" / "sample_rvu_data.csv"
+
+
+@pytest.fixture
+def sample_csv_content() -> str:
+    return SAMPLE_RVU_PATH.read_text()
+
+
+@pytest.fixture
+def sample_zip_bytes(sample_csv_content: str) -> bytes:
+    """Create an in-memory ZIP containing the sample CSV."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("PPRRVU2026_Jan_nonQPP.csv", sample_csv_content)
+    return buf.getvalue()
+
+
+# ── is_cpt_prefix ──
+
+
+def test_is_cpt_prefix_uppercase():
+    assert is_cpt_prefix("CPT") is True
+
+
+def test_is_cpt_prefix_lowercase():
+    assert is_cpt_prefix("cpt") is True
+
+
+def test_is_cpt_prefix_mixed_case():
+    assert is_cpt_prefix("Cpt") is True
+
+
+def test_is_cpt_prefix_other():
+    assert is_cpt_prefix("GO") is False
+    assert is_cpt_prefix("HP") is False
+    assert is_cpt_prefix("") is False
+
+
+# ── CPT_CODE_PATTERN ──
+
+
+def test_cpt_code_pattern_category_i():
+    assert CPT_CODE_PATTERN.match("99213")
+    assert CPT_CODE_PATTERN.match("99214")
+    assert CPT_CODE_PATTERN.match("10021")
+
+
+def test_cpt_code_pattern_category_ii():
+    assert CPT_CODE_PATTERN.match("0001F")
+    assert CPT_CODE_PATTERN.match("9999F")
+
+
+def test_cpt_code_pattern_category_iii():
+    assert CPT_CODE_PATTERN.match("0054T")
+    assert CPT_CODE_PATTERN.match("0001T")
+
+
+def test_cpt_code_pattern_rejects_hcpcs_level_ii():
+    assert CPT_CODE_PATTERN.match("G0101") is None
+    assert CPT_CODE_PATTERN.match("J1234") is None
+    assert CPT_CODE_PATTERN.match("A0001") is None
+
+
+def test_cpt_code_pattern_rejects_invalid():
+    assert CPT_CODE_PATTERN.match("9921") is None  # too short
+    assert CPT_CODE_PATTERN.match("992133") is None  # too long
+    assert CPT_CODE_PATTERN.match("9921A") is None  # wrong suffix
+
+
+# ── parse_rvu_csv ──
+
+
+def test_parse_rvu_csv_extracts_base_codes(sample_csv_content: str):
+    codes = parse_rvu_csv(sample_csv_content)
+    assert "99213" in codes
+    assert "99214" in codes
+    assert codes["99213"] == "Office o/p est low 20 min"
+    assert codes["99214"] == "Office o/p est mod 30 min"
+
+
+def test_parse_rvu_csv_excludes_modifier_rows(sample_csv_content: str):
+    codes = parse_rvu_csv(sample_csv_content)
+    # 99213 with MOD=25 should be excluded; only the base row kept
+    assert codes["99213"] == "Office o/p est low 20 min"
+    # Only one entry for 99213 (base code)
+    count_99213 = sum(1 for k in codes if k == "99213")
+    assert count_99213 == 1
+
+
+def test_parse_rvu_csv_excludes_hcpcs_level_ii(sample_csv_content: str):
+    codes = parse_rvu_csv(sample_csv_content)
+    assert "G0101" not in codes
+    assert "G0102" not in codes
+
+
+def test_parse_rvu_csv_includes_category_ii_and_iii(sample_csv_content: str):
+    codes = parse_rvu_csv(sample_csv_content)
+    assert "0001F" in codes
+    assert codes["0001F"] == "Heart failure composite"
+    assert "0054T" in codes
+    assert codes["0054T"] == "Bone integrity ultrasound"
+
+
+# ── find_rvu_csv_in_zip ──
+
+
+def test_find_rvu_csv_in_zip(sample_zip_bytes: bytes, sample_csv_content: str):
+    result = find_rvu_csv_in_zip(sample_zip_bytes)
+    assert "HCPCS" in result
+    assert "99213" in result
+
+
+def test_find_rvu_csv_in_zip_missing():
+    """ZIP with no matching CSV should raise."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("unrelated.txt", "nothing here")
+
+    with pytest.raises(Exception, match="No RVU CSV found"):
+        find_rvu_csv_in_zip(buf.getvalue())
+
+
+# ── build_cpt_cache ──
+
+
+def test_build_cpt_cache_writes_correct_format(
+    tmp_path: Path, sample_zip_bytes: bytes, monkeypatch: pytest.MonkeyPatch
+):
+    """Monkeypatch download, verify CSV output format."""
+    monkeypatch.setattr(
+        "linkml_term_validator.cpt_utils.download_rvu_zip",
+        lambda url=None: sample_zip_bytes,
+    )
+
+    cache_file = build_cpt_cache(tmp_path)
+    assert cache_file.exists()
+
+    with open(cache_file) as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 4  # 99213, 99214, 0001F, 0054T
+    assert set(reader.fieldnames or []) == {"curie", "label", "retrieved_at"}
+
+
+def test_build_cpt_cache_curie_format(
+    tmp_path: Path, sample_zip_bytes: bytes, monkeypatch: pytest.MonkeyPatch
+):
+    """CURIEs should have CPT: prefix."""
+    monkeypatch.setattr(
+        "linkml_term_validator.cpt_utils.download_rvu_zip",
+        lambda url=None: sample_zip_bytes,
+    )
+
+    cache_file = build_cpt_cache(tmp_path)
+
+    with open(cache_file) as f:
+        reader = csv.DictReader(f)
+        curies = [row["curie"] for row in reader]
+
+    assert all(c.startswith("CPT:") for c in curies)
+    assert "CPT:99213" in curies
+    assert "CPT:0001F" in curies
+    assert "CPT:0054T" in curies
+
+
+def test_build_cpt_cache_sorted(
+    tmp_path: Path, sample_zip_bytes: bytes, monkeypatch: pytest.MonkeyPatch
+):
+    """Cache entries should be sorted by CURIE."""
+    monkeypatch.setattr(
+        "linkml_term_validator.cpt_utils.download_rvu_zip",
+        lambda url=None: sample_zip_bytes,
+    )
+
+    cache_file = build_cpt_cache(tmp_path)
+
+    with open(cache_file) as f:
+        reader = csv.DictReader(f)
+        curies = [row["curie"] for row in reader]
+
+    assert curies == sorted(curies)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -378,3 +378,37 @@ def test_cli_integration(test_schema_path, cache_dir, tmp_path):
 
     # Output should contain some validation info
     assert "checked" in result.stdout.lower() or "✅" in result.stdout
+
+
+@pytest.mark.integration
+def test_cpt_download_and_build(tmp_path):
+    """Actually download CMS RVU data and verify CPT cache is built.
+
+    This test makes a real HTTP request to CMS servers.
+    """
+    from linkml_term_validator.cpt_utils import build_cpt_cache
+
+    import csv
+
+    cache_file = build_cpt_cache(tmp_path)
+
+    assert cache_file.exists()
+
+    with open(cache_file) as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    # Should have thousands of CPT codes
+    assert len(rows) > 10000, f"Expected >10000 codes, got {len(rows)}"
+
+    # Verify format
+    curies = [row["curie"] for row in rows]
+    assert all(c.startswith("CPT:") for c in curies)
+
+    # Spot-check well-known codes
+    curie_set = set(curies)
+    assert "CPT:99213" in curie_set, "Should contain common E/M code 99213"
+    assert "CPT:99214" in curie_set, "Should contain common E/M code 99214"
+
+    # Verify sorted
+    assert curies == sorted(curies)


### PR DESCRIPTION
## Summary

Experimental support for automatic CPT (Current Procedural Terminology) code validation by downloading and parsing freely-available CMS Physician Fee Schedule data.

- Adds `cpt_utils.py` module that downloads CMS RVU ZIP, extracts ~13k CPT codes (Cat I/II/III) with short descriptors, and writes standard cache format
- Hooks into `_load_cache()` in both `base.py` and `validator.py` — first time a `CPT:` prefix is encountered, auto-downloads and builds the cache
- No new dependencies (stdlib only: `urllib`, `zipfile`, `csv`)
- Lazy imports so `cpt_utils` is never loaded for non-CPT runs
- Graceful degradation: download failure prints a warning, doesn't crash
- URL overridable via `LINKML_TERM_VALIDATOR_CPT_URL` env var

## Test plan

- [x] 18 unit tests for CPT parsing, filtering, pattern matching, cache building
- [x] 9 tests for auto-build hooks in both plugin base and validator
- [x] Integration test for real CMS download (`@pytest.mark.integration`)
- [x] `just test` passes (99 tests, mypy clean, ruff clean)
- [ ] Manual test with a schema referencing CPT codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)