### PR TITLE
fix: use LF line endings in cache CSV files

### DIFF
--- a/src/linkml_term_validator/cli.py
+++ b/src/linkml_term_validator/cli.py
@@ -594,7 +594,7 @@ def migrate_cache(
                 typer.echo(f"  Would update {terms_file} ({status})")
             else:
                 with open(terms_file, "w", newline="") as f:
-                    writer = csv.DictWriter(f, fieldnames=["curie", "label", "retrieved_at"])
+                    writer = csv.DictWriter(f, fieldnames=["curie", "label", "retrieved_at"], lineterminator="\n")
                     writer.writeheader()
                     for c in sorted_curies:
                         writer.writerow(

--- a/src/linkml_term_validator/plugins/base.py
+++ b/src/linkml_term_validator/plugins/base.py
@@ -208,7 +208,7 @@ class BaseOntologyPlugin(ValidationPlugin):
 
         # Write back sorted by curie for deterministic output
         with open(cache_file, "w", newline="") as f:
-            writer = csv.DictWriter(f, fieldnames=["curie", "label", "retrieved_at"])
+            writer = csv.DictWriter(f, fieldnames=["curie", "label", "retrieved_at"], lineterminator="\n")
             writer.writeheader()
             for c in sorted(existing.keys()):
                 writer.writerow(
@@ -412,7 +412,7 @@ class BaseOntologyPlugin(ValidationPlugin):
         cache_file = self._get_enum_cache_file(enum_def.name or "unknown", cache_key)
 
         with open(cache_file, "w", newline="") as f:
-            writer = csv.DictWriter(f, fieldnames=["curie"])
+            writer = csv.DictWriter(f, fieldnames=["curie"], lineterminator="\n")
             writer.writeheader()
             for curie in sorted(values):
                 writer.writerow({"curie": curie})
@@ -436,7 +436,7 @@ class BaseOntologyPlugin(ValidationPlugin):
         file_exists = cache_file.exists()
 
         with open(cache_file, "a", newline="") as f:
-            writer = csv.DictWriter(f, fieldnames=["curie"])
+            writer = csv.DictWriter(f, fieldnames=["curie"], lineterminator="\n")
             if not file_exists:
                 writer.writeheader()
             writer.writerow({"curie": value})

--- a/src/linkml_term_validator/validator.py
+++ b/src/linkml_term_validator/validator.py
@@ -192,7 +192,7 @@ class EnumValidator:
 
         # Write back sorted by curie for deterministic output
         with open(cache_file, "w", newline="") as f:
-            writer = csv.DictWriter(f, fieldnames=["curie", "label", "retrieved_at"])
+            writer = csv.DictWriter(f, fieldnames=["curie", "label", "retrieved_at"], lineterminator="\n")
             writer.writeheader()
             for c in sorted(existing.keys()):
                 writer.writerow(

--- a/tests/test_cache_stability.py
+++ b/tests/test_cache_stability.py
@@ -22,7 +22,7 @@ def _write_terms_csv(cache_file: Path, entries: list[dict[str, str]]) -> None:
     """Helper to write a terms.csv file."""
     cache_file.parent.mkdir(parents=True, exist_ok=True)
     with open(cache_file, "w", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=["curie", "label", "retrieved_at"])
+        writer = csv.DictWriter(f, fieldnames=["curie", "label", "retrieved_at"], lineterminator="\n")
         writer.writeheader()
         for entry in entries:
             writer.writerow(entry)
@@ -211,3 +211,32 @@ class TestValidatorCacheStability:
 
         content_after = cache_file.read_text()
         assert content_before == content_after
+
+
+class TestCacheLFLineEndings:
+    """Tests that cache CSV files use LF (not CRLF) line endings. See #20."""
+
+    def test_terms_cache_uses_lf(self, cache_dir):
+        """PermissibleValueMeaningPlugin cache should use LF line endings."""
+        prefix_dir = cache_dir / "go"
+        prefix_dir.mkdir()
+
+        plugin = PermissibleValueMeaningPlugin(cache_labels=True, cache_dir=cache_dir)
+        plugin._save_to_cache("GO", "GO:0008150", "biological_process")
+
+        raw = (prefix_dir / "terms.csv").read_bytes()
+        assert b"\r\n" not in raw, "Cache file contains CRLF line endings"
+        assert b"\n" in raw, "Cache file has no newlines at all"
+
+    def test_validator_cache_uses_lf(self, cache_dir):
+        """EnumValidator cache should use LF line endings."""
+        prefix_dir = cache_dir / "go"
+        prefix_dir.mkdir()
+
+        config = ValidationConfig(cache_labels=True, cache_dir=cache_dir)
+        validator = EnumValidator(config)
+        validator._save_to_cache("GO", "GO:0008150", "biological_process")
+
+        raw = (prefix_dir / "terms.csv").read_bytes()
+        assert b"\r\n" not in raw, "Cache file contains CRLF line endings"
+        assert b"\n" in raw, "Cache file has no newlines at all"


### PR DESCRIPTION
## Summary
- Add `lineterminator='\n'` to all `csv.DictWriter` calls in `base.py`, `validator.py`, `cli.py` (migrate-cache), and the test helper
- Add tests verifying cache files contain LF, not CRLF line endings

Fixes #20

## Test plan
- [x] New `TestCacheLFLineEndings` tests verify no `\r\n` in written cache files
- [x] All 74 existing unit tests pass
- [x] Idempotent save tests still pass (test helper also updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)