### PR TITLE
Fix partial dynamic enum caches being treated as closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,8 +252,9 @@ GO:0007049,cell cycle,2025-11-15T10:30:01
 
 ### Cache Behavior
 
-- **First run**: Queries ontology databases and lazily materializes dynamic enum closures on first use
-- **Subsequent runs**: Loads warm label and enum caches from disk
+- **First run**: Queries ontology databases and stores positive enum membership hits
+- **Subsequent runs**: Loads warm label caches and any previously seen enum hits from disk
+- **Closed enum caches**: Use `--saturate-enum-caches` or `cache_strategy=greedy` to materialize full closures and write an explicit `.complete` marker
 - **Cache location**: Configurable via `--cache-dir` flag
 - **Disable all file caching**: Use `--no-cache`
 - **Disable only enum expansion caching**: Use `--no-cache-enum-expansions`
@@ -479,6 +480,7 @@ plugins:
     oak_adapter_string: "sqlite:obo:"
     cache_labels: true
     cache_enum_expansions: true
+    saturate_enum_caches: false
     cache_dir: cache
 
   # Binding constraint validation
@@ -487,6 +489,7 @@ plugins:
     validate_labels: true
     cache_labels: true
     cache_enum_expansions: true
+    saturate_enum_caches: false
     cache_dir: cache
 ```
 
@@ -513,6 +516,7 @@ See the [examples/](examples/) directory for complete examples:
   oak_adapter_string: "sqlite:obo:"  # OAK adapter (default: sqlite:obo:)
   cache_labels: true                  # Enable label caching (default: true)
   cache_enum_expansions: true         # Enable enum expansion caching (default: true)
+  saturate_enum_caches: false         # Materialize full closures and mark caches complete
   cache_dir: cache                    # Cache directory (default: cache)
   oak_config_path: oak_config.yaml    # Optional: custom OAK config
 ```
@@ -525,6 +529,7 @@ See the [examples/](examples/) directory for complete examples:
   validate_labels: true               # Check labels match ontology (default: true)
   cache_labels: true                  # Enable label caching (default: true)
   cache_enum_expansions: true         # Enable enum expansion caching (default: true)
+  saturate_enum_caches: false         # Materialize full closures and mark caches complete
   cache_dir: cache                    # Cache directory (default: cache)
   oak_config_path: oak_config.yaml    # Optional: custom OAK config
 ```

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -45,6 +45,7 @@ Dynamic enums (those using `reachable_from`, `matches`, or `concepts`) can be ca
 cache/
 └── enums/
     ├── biologicalprocessenum_abc123.csv
+    ├── biologicalprocessenum_abc123.csv.complete
     ├── cellularcomponentenum_def456.csv
     └── ...
 ```
@@ -60,6 +61,8 @@ GO:0006260
 
 The cache filename includes a hash of the enum definition, so changes to source nodes or relationship types automatically invalidate the cache.
 
+An enum cache is only treated as a **full authoritative expansion** when a sibling `.complete` marker file exists. Unmarked enum cache CSVs are treated as append-only positive membership caches.
+
 ## Enum Caching Strategies
 
 The validator supports two strategies for caching dynamic enum values:
@@ -69,19 +72,20 @@ The validator supports two strategies for caching dynamic enum values:
 **Progressive caching** validates enums lazily:
 
 1. Check in-memory cache
-2. Check file cache
-3. On first use of a dynamic enum, materialize the full closure and save it
-4. Reuse the in-memory or file cache on subsequent lookups
+2. Check file cache for positive hits
+3. If the enum cache has a `.complete` marker, treat it as the full closure
+4. Otherwise fall back to ontology reachability checks and append valid hits
+5. Optionally use `--saturate-enum-caches` to materialize the full closure and write the `.complete` marker
 
 **Benefits:**
 - Avoids upfront expansion for enums that are never used
-- Warm runs do not repeat the same `reachable_from` traversals
+- Safely reuses existing partial caches from earlier runs or versions
 - Faster startup (no upfront expansion)
-- Still scales better than eager expansion across all enums in a schema
+- Can still be promoted to a closed cache when you want warm negative lookups too
 
 **Trade-offs:**
-- First use of a dynamic enum still pays the expansion cost
-- Large closures still occupy disk and memory once cached
+- Unseen valid terms still require ontology checks until the cache is saturated
+- Full warm negative lookups require either saturation or greedy mode
 
 ### Greedy Caching
 
@@ -104,10 +108,11 @@ The validator supports two strategies for caching dynamic enum values:
 ## Cache Behavior
 
 - **First run**: Queries ontology databases and saves label / enum caches
-- **Subsequent runs**: Loads warm caches from disk (very fast, no network/database access)
+- **Subsequent runs**: Loads warm label caches, positive enum hits, and any `.complete` enum closures from disk
 - **Cache location**: Configurable via `--cache-dir` flag
 - **Disable all file caching**: Use `--no-cache`
 - **Disable only enum expansion caching**: Use `--no-cache-enum-expansions`
+- **Close enum caches on demand**: Use `--saturate-enum-caches`
 
 ## Configuration
 
@@ -125,6 +130,9 @@ linkml-term-validator validate-data data.yaml -s schema.yaml --cache-strategy gr
 
 # Use progressive caching strategy (default, lazy validation)
 linkml-term-validator validate-data data.yaml -s schema.yaml --cache-strategy progressive
+
+# In progressive mode, fully materialize and mark enum caches complete
+linkml-term-validator validate-data data.yaml -s schema.yaml --saturate-enum-caches
 ```
 
 ### Python API
@@ -139,6 +147,7 @@ plugin = DynamicEnumPlugin(
     cache_labels=True,
     cache_enum_expansions=True,
     cache_strategy=CacheStrategy.PROGRESSIVE,
+    saturate_enum_caches=False,
 )
 
 # Greedy caching - expand all upfront
@@ -156,6 +165,7 @@ plugin = BindingValidationPlugin(
 # Set cache strategy globally
 cache_strategy: progressive  # or "greedy"
 cache_enum_expansions: true
+saturate_enum_caches: false
 
 # Configure ontology adapters
 ontology_adapters:
@@ -172,6 +182,7 @@ plugins:
     oak_adapter_string: "sqlite:obo:"
     cache_labels: true
     cache_enum_expansions: true
+    saturate_enum_caches: false
     cache_dir: cache
     cache_strategy: progressive  # or "greedy"
 ```
@@ -183,11 +194,11 @@ plugins:
 | Large ontologies (SNOMED, NCBI Taxonomy) | Progressive |
 | Small, stable enums (< 1000 terms) | Greedy |
 | First-time validation of new dataset | Progressive |
-| Repeated validation of same dataset | Either (after initial cache) |
+| Repeated validation of same dataset | Progressive + `--saturate-enum-caches`, or Greedy |
 | CI/CD pipelines | Greedy (deterministic) |
 | Interactive development | Progressive (faster startup) |
 
-**Rule of thumb**: Start with progressive (the default). Switch to greedy only if you need deterministic behavior or are validating the same small dataset repeatedly.
+**Rule of thumb**: Start with progressive (the default). Use `--saturate-enum-caches` when you want to close and reuse caches without switching the whole run to greedy mode.
 
 ## When to Clear Cache
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -189,8 +189,9 @@ linkml-term-validator validate-data [OPTIONS] DATA_PATHS...
 | `--config PATH` | Path | None | Path to OAK config file |
 | `--adapter TEXT` | String | `"sqlite:obo:"` | Default OAK adapter string |
 | `--cache-dir PATH` | Path | `cache` | Directory for caching ontology labels and dynamic enums |
-| `--cache-strategy TEXT` | String | `progressive` | Caching strategy for dynamic enums: `progressive` (lazy per enum) or `greedy` (expand upfront) |
+| `--cache-strategy TEXT` | String | `progressive` | Caching strategy for dynamic enums: `progressive` (positive-hit cache) or `greedy` (expand upfront) |
 | `--cache-enum-expansions/--no-cache-enum-expansions` | Flag | True | Enable or disable file-based caching of expanded dynamic enums |
+| `--saturate-enum-caches/--no-saturate-enum-caches` | Flag | False | In progressive mode, materialize full enum closures and mark caches complete |
 | `--no-cache` | Flag | False | Disable file-based label and enum caching |
 | `--labels` | Flag | False | Validate that labels match ontology canonical labels |
 | `--lenient/--no-lenient` | Flag | False | Lenient mode: don't fail when term IDs are not found in ontology |
@@ -436,6 +437,7 @@ Controls which ontology adapters to use for different prefixes, and optionally t
 # Cache strategy (optional): "progressive" (default) or "greedy"
 cache_strategy: progressive
 cache_enum_expansions: true
+saturate_enum_caches: false
 
 ontology_adapters:
   GO: sqlite:obo:go

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,8 @@ The primary way to configure ontology access is through an `oak_config.yaml` fil
 ```yaml
 # Cache strategy for dynamic enums (optional)
 cache_strategy: progressive  # or "greedy"
+cache_enum_expansions: true
+saturate_enum_caches: false
 
 # Ontology adapter mappings
 ontology_adapters:
@@ -405,6 +407,8 @@ plugin = DynamicEnumPlugin(
     oak_adapter_string="sqlite:obo:",
     oak_config_path="oak_config.yaml",
     cache_labels=True,
+    cache_enum_expansions=True,
+    saturate_enum_caches=False,
     cache_dir="cache",
     cache_strategy=CacheStrategy.PROGRESSIVE,  # or GREEDY
 )
@@ -421,6 +425,8 @@ plugin = BindingValidationPlugin(
     oak_config_path="oak_config.yaml",
     validate_labels=True,  # Also check labels match ontology
     cache_labels=True,
+    cache_enum_expansions=True,
+    saturate_enum_caches=False,
     cache_dir="cache",
     cache_strategy=CacheStrategy.PROGRESSIVE,  # or GREEDY
 )
@@ -445,6 +451,8 @@ plugins:
   "linkml_term_validator.plugins.DynamicEnumPlugin":
     oak_adapter_string: "sqlite:obo:"
     cache_labels: true
+    cache_enum_expansions: true
+    saturate_enum_caches: false
     cache_dir: cache
     cache_strategy: progressive  # or "greedy"
     oak_config_path: oak_config.yaml
@@ -453,6 +461,8 @@ plugins:
     oak_adapter_string: "sqlite:obo:"
     validate_labels: true
     cache_labels: true
+    cache_enum_expansions: true
+    saturate_enum_caches: false
     cache_dir: cache
     cache_strategy: progressive  # or "greedy"
     oak_config_path: oak_config.yaml

--- a/src/linkml_term_validator/cli.py
+++ b/src/linkml_term_validator/cli.py
@@ -210,6 +210,13 @@ def validate_data(
             help="Enable file-based caching of expanded dynamic enum values",
         ),
     ] = True,
+    saturate_enum_caches: Annotated[
+        bool,
+        typer.Option(
+            "--saturate-enum-caches/--no-saturate-enum-caches",
+            help="Materialize full dynamic enum closures and mark enum caches complete",
+        ),
+    ] = False,
     config: Annotated[
         Optional[Path],
         typer.Option(
@@ -259,6 +266,7 @@ def validate_data(
                 cache_dir=cache_dir,
                 oak_config_path=config,
                 cache_enum_expansions=cache_enum_expansions and not no_cache,
+                saturate_enum_caches=saturate_enum_caches and not no_cache,
                 cache_strategy=strategy,
             )
         )
@@ -273,6 +281,7 @@ def validate_data(
                 cache_dir=cache_dir,
                 oak_config_path=config,
                 cache_enum_expansions=cache_enum_expansions and not no_cache,
+                saturate_enum_caches=saturate_enum_caches and not no_cache,
                 cache_strategy=strategy,
             )
         )
@@ -381,7 +390,7 @@ def validate_all(
         Path,
         typer.Option(
             "--cache-dir",
-            help="Directory for caching ontology labels",
+            help="Directory for caching ontology labels and dynamic enum expansions",
         ),
     ] = Path("cache"),
     cache_enum_expansions: Annotated[
@@ -391,6 +400,13 @@ def validate_all(
             help="Enable file-based caching of expanded dynamic enum values",
         ),
     ] = True,
+    saturate_enum_caches: Annotated[
+        bool,
+        typer.Option(
+            "--saturate-enum-caches/--no-saturate-enum-caches",
+            help="Materialize full dynamic enum closures and mark enum caches complete",
+        ),
+    ] = False,
     config: Annotated[
         Optional[Path],
         typer.Option(
@@ -444,6 +460,7 @@ def validate_all(
             no_cache=no_cache,
             cache_dir=cache_dir,
             cache_enum_expansions=cache_enum_expansions,
+            saturate_enum_caches=saturate_enum_caches,
             config=config,
             cache_strategy=cache_strategy,
         )

--- a/src/linkml_term_validator/models.py
+++ b/src/linkml_term_validator/models.py
@@ -26,7 +26,7 @@ class CacheStrategy(str, Enum):
     """
 
     PROGRESSIVE = "progressive"
-    """Lazily materialize enum caches on first use (default, scalable)."""
+    """Validate lazily and reuse positive cache hits (default, scalable)."""
 
     GREEDY = "greedy"
     """Expand entire enum upfront and cache all terms."""
@@ -238,6 +238,10 @@ class ValidationConfig(BaseModel):
         default=True,
         description="If True, cache expanded dynamic enum values to disk",
     )
+    saturate_enum_caches: bool = Field(
+        default=False,
+        description="If True, materialize full enum closures and mark enum caches complete",
+    )
     cache_strategy: CacheStrategy = Field(
         default=CacheStrategy.PROGRESSIVE,
         description="Caching strategy for dynamic enums: 'progressive' (default) or 'greedy'",
@@ -247,7 +251,8 @@ class ValidationConfig(BaseModel):
         description="Path to oak_config.yaml with per-prefix adapter settings",
     )
     cache_dir: Path = Field(
-        default=Path("cache"), description="Directory for caching ontology labels"
+        default=Path("cache"),
+        description="Directory for caching ontology labels and dynamic enum expansions",
     )
 
     def get_cache_dir(self) -> Path:

--- a/src/linkml_term_validator/plugins/base.py
+++ b/src/linkml_term_validator/plugins/base.py
@@ -45,6 +45,7 @@ class BaseOntologyPlugin(ValidationPlugin):
         oak_adapter_string: str = "sqlite:obo:",
         cache_labels: bool = True,
         cache_enum_expansions: bool = True,
+        saturate_enum_caches: bool = False,
         cache_dir: Path | str = Path("cache"),
         oak_config_path: Optional[Path | str] = None,
         cache_strategy: Literal["progressive", "greedy"] | CacheStrategy = CacheStrategy.PROGRESSIVE,
@@ -55,6 +56,7 @@ class BaseOntologyPlugin(ValidationPlugin):
             oak_adapter_string: Default OAK adapter string (e.g., "sqlite:obo:")
             cache_labels: Whether to cache ontology labels to disk
             cache_enum_expansions: Whether to cache expanded dynamic enum values to disk
+            saturate_enum_caches: Whether progressive validation should materialize full enum closures
             cache_dir: Directory for label cache files
             oak_config_path: Path to oak_config.yaml for per-prefix adapters
             cache_strategy: Caching strategy for dynamic enums - "progressive" (default) or "greedy"
@@ -67,6 +69,7 @@ class BaseOntologyPlugin(ValidationPlugin):
             oak_adapter_string=oak_adapter_string,
             cache_labels=cache_labels,
             cache_enum_expansions=cache_enum_expansions,
+            saturate_enum_caches=saturate_enum_caches,
             cache_dir=Path(cache_dir) if isinstance(cache_dir, str) else cache_dir,
             oak_config_path=(
                 Path(oak_config_path) if isinstance(oak_config_path, str) else oak_config_path
@@ -77,7 +80,8 @@ class BaseOntologyPlugin(ValidationPlugin):
         # In-memory caches
         self._label_cache: dict[str, Optional[str]] = {}
         self._adapter_cache: dict[str, object | None] = {}
-        self._enum_cache: dict[str, set[str]] = {}  # enum_name -> expanded/cached values
+        self._enum_cache: dict[str, set[str]] = {}  # enum_name -> cached values
+        self._closed_enum_caches: set[str] = set()  # enum_name -> cache is known complete
         self._unknown_prefixes: set[str] = set()
 
         # Load OAK config if provided (may override cache_strategy)
@@ -109,6 +113,10 @@ class BaseOntologyPlugin(ValidationPlugin):
             if "cache_enum_expansions" in config:
                 self.config.cache_enum_expansions = self._parse_bool_config_value(
                     config["cache_enum_expansions"], "cache_enum_expansions"
+                )
+            if "saturate_enum_caches" in config:
+                self.config.saturate_enum_caches = self._parse_bool_config_value(
+                    config["saturate_enum_caches"], "saturate_enum_caches"
                 )
 
     @staticmethod
@@ -389,6 +397,27 @@ class BaseOntologyPlugin(ValidationPlugin):
         safe_name = re.sub(r"[^\w\-]", "_", enum_name.lower())
         return enum_dir / f"{safe_name}_{cache_key}.csv"
 
+    def _get_enum_cache_marker_file(self, enum_def: EnumDefinition) -> Path:
+        """Get the completion-marker file for a fully materialized enum cache."""
+        cache_key = self._get_enum_cache_key(enum_def)
+        cache_file = self._get_enum_cache_file(enum_def.name or "unknown", cache_key)
+        return cache_file.with_suffix(f"{cache_file.suffix}.complete")
+
+    def _is_enum_cache_complete(self, enum_def: EnumDefinition) -> bool:
+        """Check whether an enum cache is explicitly marked complete."""
+        return self._get_enum_cache_marker_file(enum_def).exists()
+
+    def _mark_enum_cache_complete(self, enum_def: EnumDefinition) -> None:
+        """Mark an enum cache as a fully materialized closure."""
+        marker_file = self._get_enum_cache_marker_file(enum_def)
+        marker_file.write_text("complete\n")
+
+    def _clear_enum_cache_complete_marker(self, enum_def: EnumDefinition) -> None:
+        """Remove the completion marker so the cache is treated as partial."""
+        marker_file = self._get_enum_cache_marker_file(enum_def)
+        if marker_file.exists():
+            marker_file.unlink()
+
     def _load_enum_cache(self, enum_def: EnumDefinition) -> Optional[set[str]]:
         """Load cached enum values if available.
 
@@ -416,7 +445,7 @@ class BaseOntologyPlugin(ValidationPlugin):
                 values.add(row["curie"])
         return values
 
-    def _save_enum_cache(self, enum_def: EnumDefinition, values: set[str]) -> None:
+    def _save_enum_cache(self, enum_def: EnumDefinition, values: set[str], complete: bool = True) -> None:
         """Save expanded enum values to cache (greedy mode - writes all values).
 
         Writes a simple CSV file with header 'curie' and one CURIE per line.
@@ -437,6 +466,11 @@ class BaseOntologyPlugin(ValidationPlugin):
             for curie in sorted(values):
                 writer.writerow({"curie": curie})
 
+        if complete:
+            self._mark_enum_cache_complete(enum_def)
+        else:
+            self._clear_enum_cache_complete_marker(enum_def)
+
     def _add_to_enum_cache(self, enum_def: EnumDefinition, value: str) -> None:
         """Add a single value to the enum cache (progressive mode - appends).
 
@@ -451,6 +485,7 @@ class BaseOntologyPlugin(ValidationPlugin):
 
         cache_key = self._get_enum_cache_key(enum_def)
         cache_file = self._get_enum_cache_file(enum_def.name or "unknown", cache_key)
+        self._clear_enum_cache_complete_marker(enum_def)
 
         # Check if file exists (need to write header if not)
         file_exists = cache_file.exists()
@@ -487,8 +522,9 @@ class BaseOntologyPlugin(ValidationPlugin):
         This method is used when cache_strategy is "progressive". It:
         1. Checks the in-memory cache
         2. Checks the file cache
-        3. Optionally materializes the full enum lazily on first use
-        4. Falls back to per-value ontology checks when enum expansion caching is disabled
+        3. Reuses complete enum caches only when they are explicitly marked
+        4. Optionally saturates the cache by materializing the full enum on demand
+        5. Otherwise falls back to per-value ontology checks
 
         Args:
             value: CURIE to validate
@@ -501,22 +537,29 @@ class BaseOntologyPlugin(ValidationPlugin):
         enum_name = enum_def.name or "unknown"
 
         # 1. Check in-memory cache
-        if enum_name in self._enum_cache and value in self._enum_cache[enum_name]:
-            return True
+        if enum_name in self._enum_cache:
+            if value in self._enum_cache[enum_name]:
+                return True
+            if enum_name in self._closed_enum_caches:
+                return False
 
         # 2. Check file cache
         cached = self._load_enum_cache(enum_def)
         if cached is not None:
             # Store in memory for future lookups
             self._enum_cache[enum_name] = cached
+            if self._is_enum_cache_complete(enum_def):
+                self._closed_enum_caches.add(enum_name)
+                return value in cached
             if value in cached:
                 return True
 
-        # In progressive mode, lazily materialize the full enum on first use when
-        # enum expansion caching is enabled. This avoids repeating the same
-        # reachable_from traversal across validations while keeping expansion lazy.
+        # Progressive mode only treats a cache as authoritative when it carries an
+        # explicit completion marker. Otherwise fall back to ontology checks or
+        # opt-in saturation so legacy append-only caches remain safe.
         if (
             self.config.cache_enum_expansions
+            and self.config.saturate_enum_caches
             and self.is_dynamic_enum(enum_def)
             and schema_view is not None
         ):
@@ -679,15 +722,19 @@ class BaseOntologyPlugin(ValidationPlugin):
         """
         enum_name = enum_def.name or "unknown"
 
-        # Check in-memory cache first
-        if enum_name in self._enum_cache:
+        # Check in-memory cache first, but only trust dynamic enum caches when they
+        # are known complete.
+        if enum_name in self._enum_cache and (
+            not self.is_dynamic_enum(enum_def) or enum_name in self._closed_enum_caches
+        ):
             return self._enum_cache[enum_name]
 
-        # Check file cache for dynamic enums
-        if use_cache and self.is_dynamic_enum(enum_def):
+        # Check file cache for dynamic enums only when explicitly marked complete.
+        if use_cache and self.is_dynamic_enum(enum_def) and self._is_enum_cache_complete(enum_def):
             cached = self._load_enum_cache(enum_def)
             if cached is not None:
                 self._enum_cache[enum_name] = cached
+                self._closed_enum_caches.add(enum_name)
                 return cached
 
         # Expand the enum
@@ -733,6 +780,8 @@ class BaseOntologyPlugin(ValidationPlugin):
 
         # Cache the result
         self._enum_cache[enum_name] = values
+        if self.is_dynamic_enum(enum_def):
+            self._closed_enum_caches.add(enum_name)
         if use_cache and self.is_dynamic_enum(enum_def):
             self._save_enum_cache(enum_def, values)
 

--- a/src/linkml_term_validator/plugins/binding_plugin.py
+++ b/src/linkml_term_validator/plugins/binding_plugin.py
@@ -96,6 +96,7 @@ class BindingValidationPlugin(BaseOntologyPlugin):
         strict: bool = True,
         cache_labels: bool = True,
         cache_enum_expansions: bool = True,
+        saturate_enum_caches: bool = False,
         cache_dir: Path | str = Path("cache"),
         oak_config_path: Optional[Path | str] = None,
         cache_strategy: Literal["progressive", "greedy"] | CacheStrategy = CacheStrategy.PROGRESSIVE,
@@ -108,6 +109,7 @@ class BindingValidationPlugin(BaseOntologyPlugin):
             strict: If True (default), fail when term IDs are not found in configured ontologies
             cache_labels: Whether to cache ontology labels to disk
             cache_enum_expansions: Whether to cache expanded dynamic enum values to disk
+            saturate_enum_caches: Whether progressive validation should materialize full enum closures
             cache_dir: Directory for label cache files
             oak_config_path: Path to oak_config.yaml for per-prefix adapters
             cache_strategy: Caching strategy for dynamic enums ('progressive' or 'greedy')
@@ -116,6 +118,7 @@ class BindingValidationPlugin(BaseOntologyPlugin):
             oak_adapter_string=oak_adapter_string,
             cache_labels=cache_labels,
             cache_enum_expansions=cache_enum_expansions,
+            saturate_enum_caches=saturate_enum_caches,
             cache_dir=cache_dir,
             oak_config_path=oak_config_path,
             cache_strategy=cache_strategy,

--- a/src/linkml_term_validator/plugins/dynamic_enum_plugin.py
+++ b/src/linkml_term_validator/plugins/dynamic_enum_plugin.py
@@ -51,6 +51,7 @@ class DynamicEnumPlugin(BaseOntologyPlugin):
         oak_adapter_string: str = "sqlite:obo:",
         cache_labels: bool = True,
         cache_enum_expansions: bool = True,
+        saturate_enum_caches: bool = False,
         cache_dir: Path | str = Path("cache"),
         oak_config_path: Optional[Path | str] = None,
         cache_strategy: Literal["progressive", "greedy"] | CacheStrategy = CacheStrategy.PROGRESSIVE,
@@ -61,6 +62,7 @@ class DynamicEnumPlugin(BaseOntologyPlugin):
             oak_adapter_string: Default OAK adapter string (e.g., "sqlite:obo:")
             cache_labels: Whether to cache ontology labels to disk
             cache_enum_expansions: Whether to cache expanded dynamic enum values to disk
+            saturate_enum_caches: Whether progressive validation should materialize full enum closures
             cache_dir: Directory for label cache files
             oak_config_path: Path to oak_config.yaml for per-prefix adapters
             cache_strategy: Caching strategy for dynamic enums ('progressive' or 'greedy')
@@ -69,6 +71,7 @@ class DynamicEnumPlugin(BaseOntologyPlugin):
             oak_adapter_string=oak_adapter_string,
             cache_labels=cache_labels,
             cache_enum_expansions=cache_enum_expansions,
+            saturate_enum_caches=saturate_enum_caches,
             cache_dir=cache_dir,
             oak_config_path=oak_config_path,
             cache_strategy=cache_strategy,

--- a/tests/test_dynamic_enums.py
+++ b/tests/test_dynamic_enums.py
@@ -215,34 +215,96 @@ def test_dynamic_enum_plugin_with_cache(dynamic_enum_schema, valid_data, oak_con
 def test_dynamic_enum_plugin_progressive_warm_cache_avoids_reexpansion(
     dynamic_enum_schema, valid_data, oak_config, tmp_path
 ):
-    """Progressive mode should lazily materialize enum caches and reuse them."""
+    """Progressive mode can opt into saturated caches with an explicit marker."""
     cache_dir = tmp_path / "progressive_cache"
-    expansion_calls: list[int] = []
+    first_data = tmp_path / "first.yaml"
+    second_data = tmp_path / "second.yaml"
+    first_data.write_text("- id: sample1\n  term: TEST:0000002\n")
+    second_data.write_text("- id: sample2\n  term: TEST:0000004\n")
 
-    for _ in range(2):
-        plugin = DynamicEnumPlugin(
-            cache_dir=cache_dir,
-            oak_config_path=oak_config,
-            cache_strategy=CacheStrategy.PROGRESSIVE,
-        )
-        original_expand = plugin._expand_reachable_from
-        calls = 0
+    plugin1 = DynamicEnumPlugin(
+        cache_dir=cache_dir,
+        oak_config_path=oak_config,
+        cache_strategy=CacheStrategy.PROGRESSIVE,
+        saturate_enum_caches=True,
+    )
+    validator1 = Validator(
+        schema=str(dynamic_enum_schema),
+        validation_plugins=[plugin1],
+    )
+    report1 = validator1.validate_source(YamlLoader(first_data), target_class="Sample")
+    assert len(report1.results) == 0
 
-        def wrapped(query):
-            nonlocal calls
-            calls += 1
-            return original_expand(query)
+    enum_def = plugin1.schema_view.get_enum("RootDescendantsEnum")
+    marker_file = plugin1._get_enum_cache_marker_file(enum_def)
+    assert marker_file.exists()
 
-        plugin._expand_reachable_from = wrapped  # type: ignore[method-assign]
+    plugin2 = DynamicEnumPlugin(
+        cache_dir=cache_dir,
+        oak_config_path=oak_config,
+        cache_strategy=CacheStrategy.PROGRESSIVE,
+        saturate_enum_caches=True,
+    )
+    original_reachable = plugin2._is_value_in_reachable_from
+    reachable_calls = 0
 
-        validator = Validator(
-            schema=str(dynamic_enum_schema),
-            validation_plugins=[plugin],
-        )
-        report = validator.validate_source(YamlLoader(valid_data), target_class="Sample")
-        assert len(report.results) == 0
-        expansion_calls.append(calls)
+    def wrapped(value, query):
+        nonlocal reachable_calls
+        reachable_calls += 1
+        return original_reachable(value, query)
 
-    assert expansion_calls[0] > 0
-    assert expansion_calls[1] == 0
-    assert list((cache_dir / "enums").glob("*.csv"))
+    plugin2._is_value_in_reachable_from = wrapped  # type: ignore[method-assign]
+
+    validator2 = Validator(
+        schema=str(dynamic_enum_schema),
+        validation_plugins=[plugin2],
+    )
+    report2 = validator2.validate_source(YamlLoader(second_data), target_class="Sample")
+    assert len(report2.results) == 0
+    assert reachable_calls == 0
+
+
+def test_dynamic_enum_plugin_partial_cache_falls_back_to_ontology(
+    dynamic_enum_schema, oak_config, tmp_path
+):
+    """Unmarked enum caches are treated as partial membership caches, not full closures."""
+    from linkml_runtime import SchemaView
+
+    cache_dir = tmp_path / "partial_cache"
+    plugin = DynamicEnumPlugin(
+        cache_dir=cache_dir,
+        oak_config_path=oak_config,
+        cache_strategy=CacheStrategy.PROGRESSIVE,
+    )
+
+    validator = Validator(
+        schema=str(dynamic_enum_schema),
+        validation_plugins=[plugin],
+    )
+
+    data_path = tmp_path / "partial_cache_data.yaml"
+    data_path.write_text("- id: sample1\n  term: TEST:0000003\n")
+
+    enum_def = SchemaView(str(dynamic_enum_schema)).get_enum("RootDescendantsEnum")
+    cache_file = plugin._get_enum_cache_file(
+        enum_def.name or "unknown",
+        plugin._get_enum_cache_key(enum_def),
+    )
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text("curie\nTEST:0000002\n")
+
+    original_reachable = plugin._is_value_in_reachable_from
+    reachable_calls = 0
+
+    def wrapped(value, query):
+        nonlocal reachable_calls
+        reachable_calls += 1
+        return original_reachable(value, query)
+
+    plugin._is_value_in_reachable_from = wrapped  # type: ignore[method-assign]
+
+    report = validator.validate_source(YamlLoader(data_path), target_class="Sample")
+    assert len(report.results) == 0
+    assert reachable_calls > 0
+    assert not plugin._get_enum_cache_marker_file(enum_def).exists()
+    assert "TEST:0000003" in cache_file.read_text()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -41,6 +41,7 @@ def test_dynamic_enum_plugin_init(plugin_cache_dir):
     assert plugin is not None
     assert plugin.expanded_enums == {}
     assert plugin.config.cache_enum_expansions is True
+    assert plugin.config.saturate_enum_caches is False
 
 
 def test_binding_plugin_init(plugin_cache_dir):
@@ -54,6 +55,7 @@ def test_binding_plugin_init(plugin_cache_dir):
     assert plugin is not None
     assert plugin.validate_labels is True
     assert plugin.config.cache_enum_expansions is True
+    assert plugin.config.saturate_enum_caches is False
 
 
 @pytest.mark.integration
@@ -143,6 +145,22 @@ ontology_adapters:
     )
 
     assert plugin.config.cache_enum_expansions is False
+
+
+def test_oak_config_parses_saturate_enum_caches(plugin_cache_dir, tmp_path):
+    """YAML config should control cache saturation behavior."""
+    oak_config = tmp_path / "oak_config.yaml"
+    oak_config.write_text("""saturate_enum_caches: true
+ontology_adapters:
+  TEST: simpleobo:tests/data/test_ontology.obo
+""")
+
+    plugin = DynamicEnumPlugin(
+        oak_config_path=oak_config,
+        cache_dir=plugin_cache_dir,
+    )
+
+    assert plugin.config.saturate_enum_caches is True
 
 
 def test_binding_plugin_finds_label_slots_with_implements(plugin_cache_dir, tmp_path):
@@ -1274,6 +1292,7 @@ enums:
         for row in reader:
             cached_values.add(row["curie"])
     assert cached_values == original_values
+    assert plugin._get_enum_cache_marker_file(schema_view.get_enum("CachedEnum")).exists()
 
 
 def test_enum_caching_loads_from_file(plugin_cache_dir, tmp_path):
@@ -1342,6 +1361,7 @@ enums:
     enum_cache_dir = plugin_cache_dir / "enums"
     cache_files = list(enum_cache_dir.glob("loadtestenum_*.csv"))
     assert len(cache_files) == 1
+    assert plugin1._get_enum_cache_marker_file(schema_view.get_enum("LoadTestEnum")).exists()
 
     # Second run - should load from cache (greedy mode)
     plugin2 = BindingValidationPlugin(


### PR DESCRIPTION
## Summary

Fixes #25.

This changes dynamic enum cache semantics so progressive caches are no longer treated as authoritative full closures unless they are explicitly marked complete.

Specifically:

- treat unmarked enum cache CSVs as partial positive-hit caches
- fall back to ontology traversal on misses unless the cache is explicitly closed
- add opt-in cache saturation via `saturate_enum_caches` / `--saturate-enum-caches`
- write a `.complete` sidecar marker for fully materialized enum caches
- update docs to describe the new cache-state model

## Why

`0.4.0rc2` could mis-handle upgrade paths where an existing append-only enum cache file was present. In that situation, a partial cache could be read back as if it were the full enum expansion, which caused false negative validation results for valid uncached descendants.

This keeps progressive caches backward compatible and safe, while still allowing users to opt into fully closed caches when they want deterministic warm negative lookups.

## Validation

- `just test`
