### PR TITLE
[codex] Fix concurrent cache write corruption

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dynamic = ["version"]
 
 dependencies = [
   "typer >= 0.9.0",
+  "filelock>=3.16.1",
   "linkml-runtime >=1.9.4",
   "linkml>=1.9.3",
   "oaklib>=0.6.23",

--- a/src/linkml_term_validator/cache_utils.py
+++ b/src/linkml_term_validator/cache_utils.py
@@ -1,0 +1,50 @@
+"""Helpers for cache file locking and atomic CSV writes."""
+
+import csv
+from contextlib import contextmanager
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Iterable, Iterator, Mapping, Sequence
+
+from filelock import FileLock
+
+
+def get_cache_lock_file(cache_file: Path) -> Path:
+    """Return the sidecar lock file path for a cache file."""
+    suffix = f"{cache_file.suffix}.lock" if cache_file.suffix else ".lock"
+    return cache_file.with_suffix(suffix)
+
+
+@contextmanager
+def locked_cache_file(cache_file: Path, timeout: float = 30.0) -> Iterator[None]:
+    """Acquire an exclusive lock for a cache file using a sidecar lock file."""
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    with FileLock(str(get_cache_lock_file(cache_file)), timeout=timeout):
+        yield
+
+
+def atomic_write_csv(
+    cache_file: Path,
+    fieldnames: Sequence[str],
+    rows: Iterable[Mapping[str, str]],
+) -> None:
+    """Write CSV rows to a temp file and atomically replace the target."""
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path: Path | None = None
+    try:
+        with NamedTemporaryFile(
+            mode="w",
+            dir=cache_file.parent,
+            delete=False,
+            newline="",
+            encoding="utf-8",
+        ) as tmp:
+            tmp_path = Path(tmp.name)
+            writer = csv.DictWriter(tmp, fieldnames=list(fieldnames), lineterminator="\n")
+            writer.writeheader()
+            for row in rows:
+                writer.writerow(row)
+        tmp_path.replace(cache_file)
+    finally:
+        if tmp_path is not None and tmp_path.exists():
+            tmp_path.unlink()

--- a/src/linkml_term_validator/plugins/base.py
+++ b/src/linkml_term_validator/plugins/base.py
@@ -27,6 +27,7 @@ from linkml_runtime.linkml_model import EnumDefinition
 from oaklib import get_adapter
 from ruamel.yaml import YAML
 
+from linkml_term_validator.cache_utils import atomic_write_csv, locked_cache_file
 from linkml_term_validator.models import CacheStrategy, ValidationConfig
 
 
@@ -226,26 +227,27 @@ class BaseOntologyPlugin(ValidationPlugin):
         """
         cache_file = self._get_cache_file(prefix)
 
-        # Load existing cache with timestamps preserved
-        existing = self._load_cache_with_timestamps(prefix)
+        # Lock, re-read, merge, and atomically replace the cache file so
+        # parallel validators do not lose entries or leave truncated files.
+        with locked_cache_file(cache_file):
+            existing = self._load_cache_with_timestamps(prefix)
 
-        # Only set new timestamp if entry is new or label changed
-        now = datetime.now().isoformat()
-        if curie not in existing or existing[curie]["label"] != label:
-            existing[curie] = {"label": label, "retrieved_at": now}
+            now = datetime.now().isoformat()
+            if curie not in existing or existing[curie]["label"] != label:
+                existing[curie] = {"label": label, "retrieved_at": now}
 
-        # Write back sorted by curie for deterministic output
-        with open(cache_file, "w", newline="") as f:
-            writer = csv.DictWriter(f, fieldnames=["curie", "label", "retrieved_at"], lineterminator="\n")
-            writer.writeheader()
-            for c in sorted(existing.keys()):
-                writer.writerow(
+            atomic_write_csv(
+                cache_file,
+                ["curie", "label", "retrieved_at"],
+                (
                     {
-                        "curie": c,
-                        "label": existing[c]["label"],
-                        "retrieved_at": existing[c]["retrieved_at"],
+                        "curie": cached_curie,
+                        "label": existing[cached_curie]["label"],
+                        "retrieved_at": existing[cached_curie]["retrieved_at"],
                     }
-                )
+                    for cached_curie in sorted(existing)
+                ),
+            )
 
     def _get_adapter(self, prefix: str) -> object | None:
         """Get an OAK adapter for a prefix.
@@ -460,16 +462,17 @@ class BaseOntologyPlugin(ValidationPlugin):
         cache_key = self._get_enum_cache_key(enum_def)
         cache_file = self._get_enum_cache_file(enum_def.name or "unknown", cache_key)
 
-        with open(cache_file, "w", newline="") as f:
-            writer = csv.DictWriter(f, fieldnames=["curie"], lineterminator="\n")
-            writer.writeheader()
-            for curie in sorted(values):
-                writer.writerow({"curie": curie})
+        with locked_cache_file(cache_file):
+            atomic_write_csv(
+                cache_file,
+                ["curie"],
+                ({"curie": curie} for curie in sorted(values)),
+            )
 
-        if complete:
-            self._mark_enum_cache_complete(enum_def)
-        else:
-            self._clear_enum_cache_complete_marker(enum_def)
+            if complete:
+                self._mark_enum_cache_complete(enum_def)
+            else:
+                self._clear_enum_cache_complete_marker(enum_def)
 
     def _add_to_enum_cache(self, enum_def: EnumDefinition, value: str) -> None:
         """Add a single value to the enum cache (progressive mode - appends).
@@ -485,16 +488,17 @@ class BaseOntologyPlugin(ValidationPlugin):
 
         cache_key = self._get_enum_cache_key(enum_def)
         cache_file = self._get_enum_cache_file(enum_def.name or "unknown", cache_key)
-        self._clear_enum_cache_complete_marker(enum_def)
 
-        # Check if file exists (need to write header if not)
-        file_exists = cache_file.exists()
-
-        with open(cache_file, "a", newline="") as f:
-            writer = csv.DictWriter(f, fieldnames=["curie"], lineterminator="\n")
-            if not file_exists:
-                writer.writeheader()
-            writer.writerow({"curie": value})
+        with locked_cache_file(cache_file):
+            # Progressive caches append positive hits, but the append must still be
+            # serialized so concurrent validators do not interleave rows or headers.
+            self._clear_enum_cache_complete_marker(enum_def)
+            file_exists = cache_file.exists()
+            with open(cache_file, "a", newline="") as f:
+                writer = csv.DictWriter(f, fieldnames=["curie"], lineterminator="\n")
+                if not file_exists:
+                    writer.writeheader()
+                writer.writerow({"curie": value})
 
     def pre_process(self, context: ValidationContext) -> None:
         """Hook called before instances are processed.

--- a/src/linkml_term_validator/validator.py
+++ b/src/linkml_term_validator/validator.py
@@ -11,6 +11,7 @@ from linkml_runtime.utils.schemaview import SchemaView
 from oaklib import get_adapter
 from ruamel.yaml import YAML
 
+from linkml_term_validator.cache_utils import atomic_write_csv, locked_cache_file
 from linkml_term_validator.models import (
     SeverityLevel,
     ValidationConfig,
@@ -182,26 +183,25 @@ class EnumValidator:
 
         cache_file = self._get_cache_file(prefix)
 
-        # Load existing cache with timestamps preserved
-        existing = self._load_cache_with_timestamps(prefix)
+        with locked_cache_file(cache_file):
+            existing = self._load_cache_with_timestamps(prefix)
 
-        # Only set new timestamp if entry is new or label changed
-        now = datetime.now().isoformat()
-        if curie not in existing or existing[curie]["label"] != label:
-            existing[curie] = {"label": label, "retrieved_at": now}
+            now = datetime.now().isoformat()
+            if curie not in existing or existing[curie]["label"] != label:
+                existing[curie] = {"label": label, "retrieved_at": now}
 
-        # Write back sorted by curie for deterministic output
-        with open(cache_file, "w", newline="") as f:
-            writer = csv.DictWriter(f, fieldnames=["curie", "label", "retrieved_at"], lineterminator="\n")
-            writer.writeheader()
-            for c in sorted(existing.keys()):
-                writer.writerow(
+            atomic_write_csv(
+                cache_file,
+                ["curie", "label", "retrieved_at"],
+                (
                     {
-                        "curie": c,
-                        "label": existing[c]["label"],
-                        "retrieved_at": existing[c]["retrieved_at"],
+                        "curie": cached_curie,
+                        "label": existing[cached_curie]["label"],
+                        "retrieved_at": existing[cached_curie]["retrieved_at"],
                     }
-                )
+                    for cached_curie in sorted(existing)
+                ),
+            )
 
     def _get_adapter(self, prefix: str) -> object | None:
         """Get an OAK adapter for a prefix.

--- a/tests/test_cache_stability.py
+++ b/tests/test_cache_stability.py
@@ -1,13 +1,73 @@
 """Tests for cache stability - verifying no spurious diffs."""
 
 import csv
+import multiprocessing as mp
 from pathlib import Path
+import time
 
 import pytest
 
 from linkml_term_validator.models import ValidationConfig
 from linkml_term_validator.plugins import PermissibleValueMeaningPlugin
 from linkml_term_validator.validator import EnumValidator
+
+CONCURRENT_WRITE_DELAY = 0.2
+
+
+class SlowPermissibleValueMeaningPlugin(PermissibleValueMeaningPlugin):
+    """Delay cache reloads to widen the concurrent write window in tests."""
+
+    def _load_cache_with_timestamps(self, prefix: str) -> dict[str, dict[str, str]]:
+        cached = super()._load_cache_with_timestamps(prefix)
+        time.sleep(CONCURRENT_WRITE_DELAY)
+        return cached
+
+
+class SlowEnumValidator(EnumValidator):
+    """Delay cache reloads to widen the concurrent write window in tests."""
+
+    def _load_cache_with_timestamps(self, prefix: str) -> dict[str, dict[str, str]]:
+        cached = super()._load_cache_with_timestamps(prefix)
+        time.sleep(CONCURRENT_WRITE_DELAY)
+        return cached
+
+
+def _plugin_cache_worker(cache_dir: str, curie: str, barrier) -> None:
+    plugin = SlowPermissibleValueMeaningPlugin(cache_labels=True, cache_dir=Path(cache_dir))
+    barrier.wait()
+    plugin._save_to_cache("GO", curie, f"label-{curie}")
+
+
+def _validator_cache_worker(cache_dir: str, curie: str, barrier) -> None:
+    config = ValidationConfig(cache_labels=True, cache_dir=Path(cache_dir))
+    validator = SlowEnumValidator(config)
+    barrier.wait()
+    validator._save_to_cache("GO", curie, f"label-{curie}")
+
+
+def _run_concurrent_cache_writers(cache_dir: Path, worker) -> Path:
+    ctx = mp.get_context("spawn")
+    curies = [f"GO:{i:07d}" for i in range(1, 7)]
+    barrier = ctx.Barrier(len(curies))
+    processes = [
+        ctx.Process(target=worker, args=(str(cache_dir), curie, barrier))
+        for curie in curies
+    ]
+
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=20)
+
+    for process in processes:
+        assert process.exitcode == 0, f"worker {process.pid} failed with exit code {process.exitcode}"
+
+    cache_file = cache_dir / "go" / "terms.csv"
+    assert cache_file.exists()
+    rows = _read_terms_csv(cache_file)
+    assert [row["curie"] for row in rows] == sorted(curies)
+    assert b"\x00" not in cache_file.read_bytes()
+    return cache_file
 
 
 @pytest.fixture
@@ -148,6 +208,10 @@ class TestBasePluginCacheStability:
         content_after = cache_file.read_text()
         assert content_before == content_after
 
+    def test_concurrent_saves_preserve_all_entries(self, cache_dir):
+        """Concurrent plugin writers should serialize cache updates safely."""
+        _run_concurrent_cache_writers(cache_dir, _plugin_cache_worker)
+
 
 class TestValidatorCacheStability:
     """Tests for EnumValidator cache stability."""
@@ -211,6 +275,10 @@ class TestValidatorCacheStability:
 
         content_after = cache_file.read_text()
         assert content_before == content_after
+
+    def test_concurrent_saves_preserve_all_entries(self, cache_dir):
+        """Concurrent validator writers should serialize cache updates safely."""
+        _run_concurrent_cache_writers(cache_dir, _validator_cache_worker)
 
 
 class TestCacheLFLineEndings:

--- a/uv.lock
+++ b/uv.lock
@@ -834,6 +834,15 @@ wheels = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.25.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759 },
+]
+
+[[package]]
 name = "fqdn"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1839,6 +1848,7 @@ wheels = [
 name = "linkml-term-validator"
 source = { editable = "." }
 dependencies = [
+    { name = "filelock" },
     { name = "linkml" },
     { name = "linkml-runtime" },
     { name = "oaklib" },
@@ -1862,6 +1872,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "filelock", specifier = ">=3.16.1" },
     { name = "linkml", specifier = ">=1.9.3" },
     { name = "linkml-runtime", specifier = ">=1.9.4" },
     { name = "oaklib", specifier = ">=0.6.23" },


### PR DESCRIPTION
## Summary
- add a shared cache-write helper that uses a sidecar file lock plus atomic write-via-rename
- apply the locked atomic write path to both label cache writers and the dynamic enum cache writers
- add multiprocessing regressions that force concurrent cache writes and verify the resulting CSV remains valid
- add `filelock` as an explicit runtime dependency

## Root Cause
Cache writes in the label cache paths used a read -> merge -> overwrite flow with no lock and no atomic replace. Parallel validation processes could both lose updates and physically corrupt `terms.csv` during concurrent truncation/growth. Enum cache writes were also unsynchronized.

## Validation
- `just test`

Closes #24
