### PR TITLE
[codex] Sort progressive enum cache writes

### DIFF
--- a/src/linkml_term_validator/plugins/base.py
+++ b/src/linkml_term_validator/plugins/base.py
@@ -475,9 +475,10 @@ class BaseOntologyPlugin(ValidationPlugin):
                 self._clear_enum_cache_complete_marker(enum_def)
 
     def _add_to_enum_cache(self, enum_def: EnumDefinition, value: str) -> None:
-        """Add a single value to the enum cache (progressive mode - appends).
+        """Add a single value to the enum cache (progressive mode).
 
-        Appends a single CURIE to the cache file. Creates file with header if needed.
+        Merges the CURIE with existing cached values and rewrites the cache sorted
+        by CURIE for deterministic output.
 
         Args:
             enum_def: Enum definition
@@ -490,15 +491,14 @@ class BaseOntologyPlugin(ValidationPlugin):
         cache_file = self._get_enum_cache_file(enum_def.name or "unknown", cache_key)
 
         with locked_cache_file(cache_file):
-            # Progressive caches append positive hits, but the append must still be
-            # serialized so concurrent validators do not interleave rows or headers.
+            existing = self._load_enum_cache(enum_def) or set()
+            existing.add(value)
             self._clear_enum_cache_complete_marker(enum_def)
-            file_exists = cache_file.exists()
-            with open(cache_file, "a", newline="") as f:
-                writer = csv.DictWriter(f, fieldnames=["curie"], lineterminator="\n")
-                if not file_exists:
-                    writer.writeheader()
-                writer.writerow({"curie": value})
+            atomic_write_csv(
+                cache_file,
+                ["curie"],
+                ({"curie": curie} for curie in sorted(existing)),
+            )
 
     def pre_process(self, context: ValidationContext) -> None:
         """Hook called before instances are processed.

--- a/tests/test_cache_stability.py
+++ b/tests/test_cache_stability.py
@@ -6,9 +6,10 @@ from pathlib import Path
 import time
 
 import pytest
+from linkml_runtime.linkml_model import EnumDefinition
 
 from linkml_term_validator.models import ValidationConfig
-from linkml_term_validator.plugins import PermissibleValueMeaningPlugin
+from linkml_term_validator.plugins import DynamicEnumPlugin, PermissibleValueMeaningPlugin
 from linkml_term_validator.validator import EnumValidator
 
 CONCURRENT_WRITE_DELAY = 0.2
@@ -96,6 +97,12 @@ def _read_terms_csv(cache_file: Path) -> list[dict[str, str]]:
         for row in reader:
             rows.append(dict(row))
     return rows
+
+
+def _read_enum_csv(cache_file: Path) -> list[str]:
+    """Helper to read enum cache CURIEs."""
+    with open(cache_file) as f:
+        return [row["curie"] for row in csv.DictReader(f)]
 
 
 class TestBasePluginCacheStability:
@@ -211,6 +218,21 @@ class TestBasePluginCacheStability:
     def test_concurrent_saves_preserve_all_entries(self, cache_dir):
         """Concurrent plugin writers should serialize cache updates safely."""
         _run_concurrent_cache_writers(cache_dir, _plugin_cache_worker)
+
+    def test_progressive_enum_cache_sorts_after_each_insert(self, cache_dir):
+        """Progressive enum cache writes should stay sorted by CURIE."""
+        plugin = DynamicEnumPlugin(cache_dir=cache_dir)
+        enum_def = EnumDefinition(name="SortedEnum")
+        cache_file = plugin._get_enum_cache_file(
+            enum_def.name or "unknown",
+            plugin._get_enum_cache_key(enum_def),
+        )
+
+        plugin._add_to_enum_cache(enum_def, "TEST:0000003")
+        assert _read_enum_csv(cache_file) == ["TEST:0000003"]
+
+        plugin._add_to_enum_cache(enum_def, "TEST:0000001")
+        assert _read_enum_csv(cache_file) == ["TEST:0000001", "TEST:0000003"]
 
 
 class TestValidatorCacheStability:


### PR DESCRIPTION
## Summary

- Change progressive dynamic enum cache writes to read, merge, sort, and atomically rewrite the cache file under the existing cache lock
- Keep greedy enum cache behavior unchanged while giving progressive writes the same deterministic CURIE ordering
- Add a cache stability regression test that verifies out-of-order progressive inserts produce sorted output after each write

## Root Cause

`_save_enum_cache()` already wrote full enum expansions sorted by CURIE, but `_add_to_enum_cache()` appended positive hits in validation encounter order. That meant `cache/enums/*.csv` could churn across parallel curation branches even when the actual added CURIEs did not conflict.

## Validation

- `uv run pytest tests/test_cache_stability.py`

Closes #31
