### PR TITLE
fix: progressive dynamic-enum correctness bugs (#34-#37)

### DIFF
--- a/src/linkml_term_validator/plugins/base.py
+++ b/src/linkml_term_validator/plugins/base.py
@@ -465,23 +465,25 @@ class BaseOntologyPlugin(ValidationPlugin):
             return False  # Term doesn't exist or adapter lookup failed
 
         predicates = query.relationship_types if query.relationship_types else ["rdfs:subClassOf"]
+        include_self = query.include_self if hasattr(query, "include_self") else True
 
         # Check if value is reachable from any source node
         for source_node in query.source_nodes:
+            # Reflexive case: the source node itself.
+            if include_self and value == source_node:
+                return True
+
             if query.traverse_up:
-                # Check if source_node is an ancestor of value
-                ancestors = adapter.ancestors(value, predicates=predicates)  # type: ignore[attr-defined]
-                if ancestors and source_node in ancestors:
+                # value must be an ancestor of source_node (we traverse up from
+                # the source), i.e. value appears among source_node's ancestors.
+                ancestors = adapter.ancestors(source_node, predicates=predicates)  # type: ignore[attr-defined]
+                if ancestors and value in ancestors:
                     return True
             else:
-                # Check if value is a descendant of source_node
-                # We do this by checking if source_node is an ancestor of value
+                # value must be a descendant of source_node, i.e. source_node
+                # appears among value's ancestors.
                 ancestors = adapter.ancestors(value, predicates=predicates)  # type: ignore[attr-defined]
                 if ancestors and source_node in ancestors:
-                    return True
-                # Also check include_self
-                include_self = query.include_self if hasattr(query, "include_self") else True
-                if include_self and value == source_node:
                     return True
 
         return False

--- a/src/linkml_term_validator/plugins/base.py
+++ b/src/linkml_term_validator/plugins/base.py
@@ -687,30 +687,29 @@ class BaseOntologyPlugin(ValidationPlugin):
         # Get relationship types (predicates)
         predicates = query.relationship_types if query.relationship_types else ["rdfs:subClassOf"]
 
-        # Use OAK to get descendants or ancestors
+        # Use OAK to get descendants or ancestors. A query failure is allowed to
+        # propagate: expand_enum writes its cache only after a fully successful
+        # expansion, so a partial/empty result is never persisted as complete
+        # (see #35).
         for source_node in query.source_nodes:
-            try:
-                if query.traverse_up:
-                    # Get ancestors
-                    ancestors_result = adapter.ancestors(  # type: ignore[attr-defined]
-                        source_node,
-                        predicates=predicates,
-                        reflexive=query.include_self if hasattr(query, "include_self") else False,
-                    )
-                    if ancestors_result:
-                        values.update(ancestors_result)
-                else:
-                    # Get descendants (default)
-                    descendants_result = adapter.descendants(  # type: ignore[attr-defined]
-                        source_node,
-                        predicates=predicates,
-                        reflexive=query.include_self if hasattr(query, "include_self") else True,
-                    )
-                    if descendants_result:
-                        values.update(descendants_result)
-            except Exception:
-                # If OAK query fails, skip this source node
-                pass
+            if query.traverse_up:
+                # Get ancestors
+                ancestors_result = adapter.ancestors(  # type: ignore[attr-defined]
+                    source_node,
+                    predicates=predicates,
+                    reflexive=query.include_self if hasattr(query, "include_self") else False,
+                )
+                if ancestors_result:
+                    values.update(ancestors_result)
+            else:
+                # Get descendants (default)
+                descendants_result = adapter.descendants(  # type: ignore[attr-defined]
+                    source_node,
+                    predicates=predicates,
+                    reflexive=query.include_self if hasattr(query, "include_self") else True,
+                )
+                if descendants_result:
+                    values.update(descendants_result)
 
         return values
 

--- a/src/linkml_term_validator/plugins/base.py
+++ b/src/linkml_term_validator/plugins/base.py
@@ -221,12 +221,17 @@ class BaseOntologyPlugin(ValidationPlugin):
         return hashlib.md5(key_string.encode()).hexdigest()[:12]
 
     @staticmethod
+    def _reachable_from_include_self(query: Any) -> bool:
+        """Return the effective include_self value for a reachable_from query."""
+        return bool(getattr(query, "include_self", False))
+
+    @staticmethod
     def _reachability_key(query: Any) -> str:
         """Serialize a reachable_from query deterministically for cache keys."""
         parts = [
             f"rf:{','.join(sorted(query.source_nodes or []))}",
             f"rt:{','.join(sorted(query.relationship_types or []))}",
-            f"is:{query.include_self if hasattr(query, 'include_self') else True}",
+            f"is:{BaseOntologyPlugin._reachable_from_include_self(query)}",
             f"tu:{query.traverse_up if hasattr(query, 'traverse_up') else False}",
         ]
         return "|".join(parts)
@@ -496,7 +501,7 @@ class BaseOntologyPlugin(ValidationPlugin):
             return False  # Term doesn't exist or adapter lookup failed
 
         predicates = query.relationship_types if query.relationship_types else ["rdfs:subClassOf"]
-        include_self = query.include_self if hasattr(query, "include_self") else True
+        include_self = self._reachable_from_include_self(query)
 
         # Check if value is reachable from any source node
         for source_node in query.source_nodes:
@@ -507,13 +512,21 @@ class BaseOntologyPlugin(ValidationPlugin):
             if query.traverse_up:
                 # value must be an ancestor of source_node (we traverse up from
                 # the source), i.e. value appears among source_node's ancestors.
-                ancestors = adapter.ancestors(source_node, predicates=predicates)  # type: ignore[attr-defined]
+                ancestors = adapter.ancestors(  # type: ignore[attr-defined]
+                    source_node,
+                    predicates=predicates,
+                    reflexive=include_self,
+                )
                 if ancestors and value in ancestors:
                     return True
             else:
                 # value must be a descendant of source_node, i.e. source_node
                 # appears among value's ancestors.
-                ancestors = adapter.ancestors(value, predicates=predicates)  # type: ignore[attr-defined]
+                ancestors = adapter.ancestors(  # type: ignore[attr-defined]
+                    value,
+                    predicates=predicates,
+                    reflexive=include_self,
+                )
                 if ancestors and source_node in ancestors:
                     return True
 
@@ -722,13 +735,14 @@ class BaseOntologyPlugin(ValidationPlugin):
         # propagate: expand_enum writes its cache only after a fully successful
         # expansion, so a partial/empty result is never persisted as complete
         # (see #35).
+        include_self = self._reachable_from_include_self(query)
         for source_node in query.source_nodes:
             if query.traverse_up:
                 # Get ancestors
                 ancestors_result = adapter.ancestors(  # type: ignore[attr-defined]
                     source_node,
                     predicates=predicates,
-                    reflexive=query.include_self if hasattr(query, "include_self") else False,
+                    reflexive=include_self,
                 )
                 if ancestors_result:
                     values.update(ancestors_result)
@@ -737,7 +751,7 @@ class BaseOntologyPlugin(ValidationPlugin):
                 descendants_result = adapter.descendants(  # type: ignore[attr-defined]
                     source_node,
                     predicates=predicates,
-                    reflexive=query.include_self if hasattr(query, "include_self") else True,
+                    reflexive=include_self,
                 )
                 if descendants_result:
                     values.update(descendants_result)

--- a/src/linkml_term_validator/plugins/base.py
+++ b/src/linkml_term_validator/plugins/base.py
@@ -16,6 +16,7 @@ Example:
 
 import csv
 import hashlib
+import json
 import re
 from pathlib import Path
 from typing import Any, Literal, Optional
@@ -203,6 +204,12 @@ class BaseOntologyPlugin(ValidationPlugin):
         if enum_def.concepts:
             key_parts.append(f"c:{','.join(sorted(enum_def.concepts))}")
 
+        if enum_def.matches:
+            key_parts.append(f"m:{self._matches_key(enum_def.matches)}")
+
+        if enum_def.permissible_values:
+            key_parts.append(f"pv:{self._permissible_values_key(enum_def.permissible_values)}")
+
         # Set-operation clauses also change the expanded value set; sort so the
         # key is independent of clause ordering.
         if enum_def.include:
@@ -229,22 +236,50 @@ class BaseOntologyPlugin(ValidationPlugin):
     def _reachability_key(query: Any) -> str:
         """Serialize a reachable_from query deterministically for cache keys."""
         parts = [
-            f"rf:{','.join(sorted(query.source_nodes or []))}",
+            f"sn:{','.join(sorted(query.source_nodes or []))}",
             f"rt:{','.join(sorted(query.relationship_types or []))}",
             f"is:{BaseOntologyPlugin._reachable_from_include_self(query)}",
             f"tu:{query.traverse_up if hasattr(query, 'traverse_up') else False}",
         ]
         return "|".join(parts)
 
+    @staticmethod
+    def _matches_key(query: Any) -> str:
+        """Serialize a matches query deterministically for cache keys."""
+        source_ontology = getattr(query, "source_ontology", None)
+        return json.dumps(
+            {
+                "identifier_pattern": getattr(query, "identifier_pattern", None),
+                "source_ontology": str(source_ontology) if source_ontology is not None else None,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    @staticmethod
+    def _permissible_values_key(permissible_values: Any) -> str:
+        """Serialize permissible values as the expanded names and meanings."""
+        parts = []
+        items = permissible_values.items() if hasattr(permissible_values, "items") else permissible_values._items()
+        for pv_name, pv in items:
+            if isinstance(pv, dict):
+                meaning = pv.get("meaning")
+            else:
+                meaning = getattr(pv, "meaning", None)
+            parts.append([str(pv_name), str(meaning) if meaning is not None else None])
+        return json.dumps(sorted(parts), separators=(",", ":"))
+
     def _enum_expression_key(self, expr: Any) -> str:
         """Serialize an include/minus enum expression deterministically."""
         parts: list[str] = []
         if getattr(expr, "reachable_from", None):
             parts.append(self._reachability_key(expr.reachable_from))
+        if getattr(expr, "matches", None):
+            parts.append(f"m:{self._matches_key(expr.matches)}")
         if getattr(expr, "concepts", None):
             parts.append(f"c:{','.join(sorted(expr.concepts))}")
         if getattr(expr, "permissible_values", None):
-            parts.append(f"pv:{','.join(sorted(expr.permissible_values))}")
+            parts.append(f"pv:{self._permissible_values_key(expr.permissible_values)}")
         return "(" + "|".join(parts) + ")"
 
     def _get_enum_cache_file(self, enum_name: str, cache_key: str) -> Path:

--- a/src/linkml_term_validator/plugins/base.py
+++ b/src/linkml_term_validator/plugins/base.py
@@ -185,9 +185,9 @@ class BaseOntologyPlugin(ValidationPlugin):
     def _get_enum_cache_key(self, enum_def: EnumDefinition) -> str:
         """Generate a cache key from enum definition.
 
-        The key is based on the dynamic query parameters (source_nodes,
-        relationship_types, include_self, traverse_up) so the cache is
-        invalidated when the enum definition changes.
+        The key incorporates every dynamic construct that affects the expanded
+        value set (reachable_from, concepts, include, minus, inherits) so the
+        cache is invalidated when any of them changes.
 
         Args:
             enum_def: Enum definition
@@ -198,18 +198,49 @@ class BaseOntologyPlugin(ValidationPlugin):
         key_parts = [enum_def.name or ""]
 
         if enum_def.reachable_from:
-            query = enum_def.reachable_from
-            key_parts.append(f"rf:{','.join(sorted(query.source_nodes or []))}")
-            key_parts.append(f"rt:{','.join(sorted(query.relationship_types or []))}")
-            key_parts.append(f"is:{query.include_self if hasattr(query, 'include_self') else True}")
-            key_parts.append(f"tu:{query.traverse_up if hasattr(query, 'traverse_up') else False}")
+            key_parts.append(f"rf:{self._reachability_key(enum_def.reachable_from)}")
 
         if enum_def.concepts:
             key_parts.append(f"c:{','.join(sorted(enum_def.concepts))}")
 
+        # Set-operation clauses also change the expanded value set; sort so the
+        # key is independent of clause ordering.
+        if enum_def.include:
+            key_parts.append(
+                "inc:" + ",".join(sorted(self._enum_expression_key(e) for e in enum_def.include))
+            )
+        if enum_def.minus:
+            key_parts.append(
+                "min:" + ",".join(sorted(self._enum_expression_key(e) for e in enum_def.minus))
+            )
+        if enum_def.inherits:
+            key_parts.append(f"inh:{','.join(sorted(enum_def.inherits))}")
+
         # Create a short hash for filename
         key_string = "|".join(key_parts)
         return hashlib.md5(key_string.encode()).hexdigest()[:12]
+
+    @staticmethod
+    def _reachability_key(query: Any) -> str:
+        """Serialize a reachable_from query deterministically for cache keys."""
+        parts = [
+            f"rf:{','.join(sorted(query.source_nodes or []))}",
+            f"rt:{','.join(sorted(query.relationship_types or []))}",
+            f"is:{query.include_self if hasattr(query, 'include_self') else True}",
+            f"tu:{query.traverse_up if hasattr(query, 'traverse_up') else False}",
+        ]
+        return "|".join(parts)
+
+    def _enum_expression_key(self, expr: Any) -> str:
+        """Serialize an include/minus enum expression deterministically."""
+        parts: list[str] = []
+        if getattr(expr, "reachable_from", None):
+            parts.append(self._reachability_key(expr.reachable_from))
+        if getattr(expr, "concepts", None):
+            parts.append(f"c:{','.join(sorted(expr.concepts))}")
+        if getattr(expr, "permissible_values", None):
+            parts.append(f"pv:{','.join(sorted(expr.permissible_values))}")
+        return "(" + "|".join(parts) + ")"
 
     def _get_enum_cache_file(self, enum_name: str, cache_key: str) -> Path:
         """Get the cache file path for an enum.

--- a/tests/test_reachable_from_progressive.py
+++ b/tests/test_reachable_from_progressive.py
@@ -1,0 +1,58 @@
+"""Progressive-validation tests for reachable_from semantics and cache safety.
+
+Covers regression tests for:
+- #34 traverse_up must include ancestors, not behave like traverse_down
+- #35 a failed expansion must not be cached as a complete closure
+- #36 the enum cache key must change when include/minus/inherits change
+
+Uses the local simpleobo test ontology (offline). Hierarchy:
+
+    TEST:0000001 root
+      TEST:0000002 child one
+        TEST:0000004 grandchild
+      TEST:0000003 child two
+    TEST:0000005 biological_process
+      TEST:0000006 cell_cycle
+"""
+
+from pathlib import Path
+
+import pytest
+from linkml_runtime.linkml_model.meta import EnumDefinition, ReachabilityQuery
+
+from linkml_term_validator.plugins import DynamicEnumPlugin
+
+OAK_CONFIG = Path("tests/data/test_oak_config.yaml")
+
+
+@pytest.fixture
+def plugin(tmp_path):
+    """A progressive-mode plugin wired to the local test ontology."""
+    return DynamicEnumPlugin(
+        oak_config_path=OAK_CONFIG,
+        cache_labels=False,
+        cache_enum_expansions=False,
+        cache_dir=tmp_path / "cache",
+    )
+
+
+def test_traverse_up_includes_ancestors_not_descendants(plugin):
+    """#34: traverse_up should accept ancestors of the source node, reject siblings.
+
+    Source node is child-one (TEST:0000002). Going up, its ancestor is the
+    root (TEST:0000001), which must be valid. Child-two (TEST:0000003) is a
+    sibling, not an ancestor, so it must be rejected.
+    """
+    enum_def = EnumDefinition(
+        name="AncestorsOfChildOne",
+        reachable_from=ReachabilityQuery(
+            source_nodes=["TEST:0000002"],
+            relationship_types=["rdfs:subClassOf"],
+            traverse_up=True,
+        ),
+    )
+
+    # Root is an ancestor of child-one → valid under traverse_up.
+    assert plugin.is_value_in_enum("TEST:0000001", enum_def) is True
+    # Child-two is a sibling, not an ancestor → invalid.
+    assert plugin.is_value_in_enum("TEST:0000003", enum_def) is False

--- a/tests/test_reachable_from_progressive.py
+++ b/tests/test_reachable_from_progressive.py
@@ -18,7 +18,11 @@ Uses the local simpleobo test ontology (offline). Hierarchy:
 from pathlib import Path
 
 import pytest
-from linkml_runtime.linkml_model.meta import EnumDefinition, ReachabilityQuery
+from linkml_runtime.linkml_model.meta import (
+    AnonymousEnumExpression,
+    EnumDefinition,
+    ReachabilityQuery,
+)
 
 from linkml_term_validator.plugins import DynamicEnumPlugin
 
@@ -97,3 +101,52 @@ def test_failed_expansion_is_not_cached_as_complete(tmp_path):
 
     # And the cache must not have been marked complete.
     assert plugin._is_enum_cache_complete(enum_def) is False
+
+
+def _base_enum() -> EnumDefinition:
+    return EnumDefinition(
+        name="E",
+        reachable_from=ReachabilityQuery(
+            source_nodes=["TEST:0000001"],
+            relationship_types=["rdfs:subClassOf"],
+        ),
+    )
+
+
+def _with_inherits() -> EnumDefinition:
+    e = _base_enum()
+    e.inherits = ["ParentEnum"]
+    return e
+
+
+def _with_include() -> EnumDefinition:
+    e = _base_enum()
+    e.include = [AnonymousEnumExpression(concepts=["TEST:0000006"])]
+    return e
+
+
+def _with_minus() -> EnumDefinition:
+    e = _base_enum()
+    e.minus = [AnonymousEnumExpression(concepts=["TEST:0000006"])]
+    return e
+
+
+@pytest.mark.parametrize(
+    "variant",
+    [_with_inherits, _with_include, _with_minus],
+    ids=["inherits", "include", "minus"],
+)
+def test_cache_key_changes_with_set_operation_clause(tmp_path, variant):
+    """#36: include / minus / inherits must participate in the enum cache key.
+
+    Two enums identical except for one of these clauses must not collide on
+    the same cache file, otherwise editing the clause returns stale results.
+    """
+    plugin = DynamicEnumPlugin(
+        cache_labels=False,
+        cache_enum_expansions=False,
+        cache_dir=tmp_path / "cache",
+    )
+    base_key = plugin._get_enum_cache_key(_base_enum())
+    variant_key = plugin._get_enum_cache_key(variant())
+    assert base_key != variant_key

--- a/tests/test_reachable_from_progressive.py
+++ b/tests/test_reachable_from_progressive.py
@@ -23,6 +23,8 @@ import pytest
 from linkml_runtime.linkml_model.meta import (
     AnonymousEnumExpression,
     EnumDefinition,
+    MatchQuery,
+    PermissibleValue,
     ReachabilityQuery,
 )
 
@@ -191,6 +193,28 @@ def _with_minus() -> EnumDefinition:
     return e
 
 
+def _with_top_level_permissible_value(meaning: str) -> EnumDefinition:
+    e = _base_enum()
+    e.permissible_values = {"EXTRA": PermissibleValue(text="EXTRA", meaning=meaning)}
+    return e
+
+
+def _with_include_match(pattern: str) -> EnumDefinition:
+    e = _base_enum()
+    e.include = [AnonymousEnumExpression(matches=MatchQuery(identifier_pattern=pattern))]
+    return e
+
+
+def _with_include_permissible_value(meaning: str) -> EnumDefinition:
+    e = _base_enum()
+    e.include = [
+        AnonymousEnumExpression(
+            permissible_values={"EXTRA": PermissibleValue(text="EXTRA", meaning=meaning)}
+        )
+    ]
+    return e
+
+
 @pytest.mark.parametrize(
     "variant",
     [_with_inherits, _with_include, _with_minus],
@@ -210,3 +234,55 @@ def test_cache_key_changes_with_set_operation_clause(tmp_path, variant):
     base_key = plugin._get_enum_cache_key(_base_enum())
     variant_key = plugin._get_enum_cache_key(variant())
     assert base_key != variant_key
+
+
+def test_cache_key_changes_with_top_level_matches_clause(tmp_path):
+    """#36: matches clauses must participate in the enum cache key."""
+    plugin = DynamicEnumPlugin(
+        cache_labels=False,
+        cache_enum_expansions=False,
+        cache_dir=tmp_path / "cache",
+    )
+    enum1 = EnumDefinition(name="E", matches=MatchQuery(identifier_pattern="TEST:000000[12]"))
+    enum2 = EnumDefinition(name="E", matches=MatchQuery(identifier_pattern="TEST:000000[34]"))
+
+    assert plugin._get_enum_cache_key(enum1) != plugin._get_enum_cache_key(enum2)
+
+
+def test_cache_key_changes_with_top_level_permissible_value_meaning(tmp_path):
+    """#36: top-level permissible value meanings affect expanded enum values."""
+    plugin = DynamicEnumPlugin(
+        cache_labels=False,
+        cache_enum_expansions=False,
+        cache_dir=tmp_path / "cache",
+    )
+
+    key1 = plugin._get_enum_cache_key(_with_top_level_permissible_value("TEST:0000002"))
+    key2 = plugin._get_enum_cache_key(_with_top_level_permissible_value("TEST:0000003"))
+    assert key1 != key2
+
+
+def test_cache_key_changes_with_include_match_clause(tmp_path):
+    """#36: include/minus expression matches clauses must affect the cache key."""
+    plugin = DynamicEnumPlugin(
+        cache_labels=False,
+        cache_enum_expansions=False,
+        cache_dir=tmp_path / "cache",
+    )
+
+    key1 = plugin._get_enum_cache_key(_with_include_match("TEST:000000[12]"))
+    key2 = plugin._get_enum_cache_key(_with_include_match("TEST:000000[34]"))
+    assert key1 != key2
+
+
+def test_cache_key_changes_with_include_permissible_value_meaning(tmp_path):
+    """#36: include/minus expression permissible value meanings affect the cache key."""
+    plugin = DynamicEnumPlugin(
+        cache_labels=False,
+        cache_enum_expansions=False,
+        cache_dir=tmp_path / "cache",
+    )
+
+    key1 = plugin._get_enum_cache_key(_with_include_permissible_value("TEST:0000002"))
+    key2 = plugin._get_enum_cache_key(_with_include_permissible_value("TEST:0000003"))
+    assert key1 != key2

--- a/tests/test_reachable_from_progressive.py
+++ b/tests/test_reachable_from_progressive.py
@@ -56,3 +56,44 @@ def test_traverse_up_includes_ancestors_not_descendants(plugin):
     assert plugin.is_value_in_enum("TEST:0000001", enum_def) is True
     # Child-two is a sibling, not an ancestor → invalid.
     assert plugin.is_value_in_enum("TEST:0000003", enum_def) is False
+
+
+class _BoomAdapter:
+    """Adapter stub whose graph queries fail, simulating a backend outage."""
+
+    def descendants(self, *args, **kwargs):
+        raise RuntimeError("ontology backend unavailable")
+
+    def ancestors(self, *args, **kwargs):
+        raise RuntimeError("ontology backend unavailable")
+
+
+def test_failed_expansion_is_not_cached_as_complete(tmp_path):
+    """#35: a failed reachable_from expansion must not be persisted as complete.
+
+    Previously the OAK query exception was swallowed, yielding an empty set
+    that was written to disk and marked complete — poisoning every later run.
+    """
+    plugin = DynamicEnumPlugin(
+        oak_config_path=OAK_CONFIG,
+        cache_labels=False,
+        cache_enum_expansions=True,  # caching on, so we can inspect the marker
+        cache_dir=tmp_path / "cache",
+    )
+    # Force the adapter for the TEST prefix to fail on graph queries.
+    plugin.ontology._adapter_cache["TEST"] = _BoomAdapter()
+
+    enum_def = EnumDefinition(
+        name="BoomEnum",
+        reachable_from=ReachabilityQuery(
+            source_nodes=["TEST:0000005"],
+            relationship_types=["rdfs:subClassOf"],
+        ),
+    )
+
+    # The failure must surface, not be silently swallowed.
+    with pytest.raises(RuntimeError):
+        plugin.expand_enum(enum_def, use_cache=True)
+
+    # And the cache must not have been marked complete.
+    assert plugin._is_enum_cache_complete(enum_def) is False

--- a/tests/test_reachable_from_progressive.py
+++ b/tests/test_reachable_from_progressive.py
@@ -4,6 +4,7 @@ Covers regression tests for:
 - #34 traverse_up must include ancestors, not behave like traverse_down
 - #35 a failed expansion must not be cached as a complete closure
 - #36 the enum cache key must change when include/minus/inherits change
+- #37 include_self defaults and explicit values must be consistent
 
 Uses the local simpleobo test ontology (offline). Hierarchy:
 
@@ -16,6 +17,7 @@ Uses the local simpleobo test ontology (offline). Hierarchy:
 """
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from linkml_runtime.linkml_model.meta import (
@@ -60,6 +62,64 @@ def test_traverse_up_includes_ancestors_not_descendants(plugin):
     assert plugin.is_value_in_enum("TEST:0000001", enum_def) is True
     # Child-two is a sibling, not an ancestor → invalid.
     assert plugin.is_value_in_enum("TEST:0000003", enum_def) is False
+
+
+@pytest.mark.parametrize(
+    ("traverse_up", "source_node", "reachable_node"),
+    [
+        (False, "TEST:0000002", "TEST:0000004"),
+        (True, "TEST:0000002", "TEST:0000001"),
+    ],
+    ids=["descendants", "ancestors"],
+)
+def test_missing_include_self_defaults_to_excluding_source_node(
+    plugin, traverse_up, source_node, reachable_node
+):
+    """#37: missing include_self should consistently exclude the source node."""
+    query = SimpleNamespace(
+        source_nodes=[source_node],
+        relationship_types=["rdfs:subClassOf"],
+        traverse_up=traverse_up,
+    )
+
+    assert plugin._is_value_in_reachable_from(source_node, query) is False
+    assert plugin._is_value_in_reachable_from(reachable_node, query) is True
+
+    expanded = plugin._expand_reachable_from(query)
+    assert source_node not in expanded
+    assert reachable_node in expanded
+
+
+@pytest.mark.parametrize(
+    ("traverse_up", "source_node", "reachable_node"),
+    [
+        (False, "TEST:0000002", "TEST:0000004"),
+        (True, "TEST:0000002", "TEST:0000001"),
+    ],
+    ids=["descendants", "ancestors"],
+)
+@pytest.mark.parametrize(
+    ("include_self", "source_is_reachable"),
+    [(False, False), (True, True)],
+    ids=["include-self-false", "include-self-true"],
+)
+def test_include_self_is_honored_in_progressive_and_expanded_paths(
+    plugin, traverse_up, source_node, reachable_node, include_self, source_is_reachable
+):
+    """#37: include_self should behave the same in per-value and expanded paths."""
+    query = ReachabilityQuery(
+        source_nodes=[source_node],
+        relationship_types=["rdfs:subClassOf"],
+        traverse_up=traverse_up,
+        include_self=include_self,
+    )
+
+    assert plugin._is_value_in_reachable_from(source_node, query) is source_is_reachable
+    assert plugin._is_value_in_reachable_from(reachable_node, query) is True
+
+    expanded = plugin._expand_reachable_from(query)
+    assert (source_node in expanded) is source_is_reachable
+    assert reachable_node in expanded
 
 
 class _BoomAdapter:


### PR DESCRIPTION
Fixes four progressive dynamic-enum correctness bugs. Each fix is covered in `tests/test_reachable_from_progressive.py`.

Closes #34
Closes #35
Closes #36
Closes #37

## #34 — `traverse_up` behaved identically to `traverse_down`
`_is_value_in_reachable_from` checked `source_node in ancestors(value)` in both branches. For `traverse_up`, the value should be an ancestor of the source node. The up direction now checks `value in ancestors(source_node)`.

## #35 — a transient ontology failure poisoned the cache as complete
`_expand_reachable_from` swallowed OAK query exceptions, allowing empty or partial expansions to be cached as complete. Query failures now propagate, so `expand_enum` only writes a complete cache after a successful expansion.

## #36 — enum cache key ignored fields that affect expansion
The enum cache key now includes all dynamic set-operation clauses, top-level `matches`, top-level permissible-value names and meanings, and include/minus expression `matches` plus permissible-value names and meanings. This prevents stale complete caches after schema edits.

## #37 — `include_self` behavior was inconsistent
The effective `include_self` value is now normalized with the LinkML default of excluding source nodes, and both progressive per-value checks and greedy expansion pass the same reflexive setting into OAK for both traversal directions.

## Test plan
- [x] `uv run pytest tests/test_reachable_from_progressive.py -q` — 15 passed
- [x] `just test` — 128 passed, 12 deselected; mypy clean; ruff clean
