### PR TITLE
fix: handle non-string binding labels (#38)

### DIFF
--- a/src/linkml_term_validator/plugins/binding_plugin.py
+++ b/src/linkml_term_validator/plugins/binding_plugin.py
@@ -627,10 +627,52 @@ class BindingValidationPlugin(BaseOntologyPlugin):
             ontology_label = self.get_ontology_label(field_value)
 
             if ontology_label:
-                normalized_provided = self.normalize_string(provided_label)
+                if isinstance(provided_label, str):
+                    provided_labels = [provided_label]
+                elif isinstance(provided_label, list):
+                    provided_labels = [label for label in provided_label if isinstance(label, str)]
+                    if not provided_labels:
+                        yield ValidationResult(
+                            type="binding_label_invalid",
+                            severity=Severity.WARN,
+                            message=(
+                                f"Label field '{label_field}' for '{field_value}' must contain "
+                                f"a string label, got '{provided_label}'"
+                            ),
+                            instance=instance,
+                            instantiates=target_class,
+                            context=[
+                                f"path: {path}",
+                                f"slot: {slot_name}",
+                                f"label_field: {label_field}",
+                                f"curie: {field_value}",
+                            ],
+                        )
+                        continue
+                else:
+                    yield ValidationResult(
+                        type="binding_label_invalid",
+                        severity=Severity.WARN,
+                        message=(
+                            f"Label field '{label_field}' for '{field_value}' must be a string "
+                            f"or list of strings, got {type(provided_label).__name__}"
+                        ),
+                        instance=instance,
+                        instantiates=target_class,
+                        context=[
+                            f"path: {path}",
+                            f"slot: {slot_name}",
+                            f"label_field: {label_field}",
+                            f"curie: {field_value}",
+                        ],
+                    )
+                    continue
+
                 normalized_ontology = self.normalize_string(ontology_label)
 
-                if normalized_provided != normalized_ontology:
+                if not any(
+                    self.normalize_string(label) == normalized_ontology for label in provided_labels
+                ):
                     yield ValidationResult(
                         type="binding_label_mismatch",
                         severity=Severity.WARN,

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -312,6 +312,67 @@ classes:
     assert "title" not in label_slots
 
 
+def test_binding_plugin_non_string_label_reports_warning(plugin_cache_dir):
+    """Non-string label values should report a validation result, not crash."""
+    plugin = BindingValidationPlugin(validate_labels=True, cache_dir=plugin_cache_dir)
+    plugin.get_ontology_label = lambda curie: "child term one"  # type: ignore[method-assign]
+
+    results = list(
+        plugin._validate_label(
+            value={"label": None},
+            field_value="TEST:0000002",
+            slot_name="term",
+            instance={"term": {"id": "TEST:0000002", "label": None}},
+            target_class="Annotation",
+            path="term",
+        )
+    )
+
+    assert len(results) == 1
+    assert results[0].type == "binding_label_invalid"
+    assert "must be a string" in results[0].message
+
+
+def test_binding_plugin_list_label_matches_any_string(plugin_cache_dir):
+    """Multivalued label slots should pass when any string label matches."""
+    plugin = BindingValidationPlugin(validate_labels=True, cache_dir=plugin_cache_dir)
+    plugin.get_ontology_label = lambda curie: "child term one"  # type: ignore[method-assign]
+
+    results = list(
+        plugin._validate_label(
+            value={"label": ["alternate label", "child term one"]},
+            field_value="TEST:0000002",
+            slot_name="term",
+            instance={"term": {"id": "TEST:0000002", "label": ["alternate label", "child term one"]}},
+            target_class="Annotation",
+            path="term",
+        )
+    )
+
+    assert results == []
+
+
+def test_binding_plugin_list_label_mismatch_reports_warning(plugin_cache_dir):
+    """Multivalued label slots should warn when no string label matches."""
+    plugin = BindingValidationPlugin(validate_labels=True, cache_dir=plugin_cache_dir)
+    plugin.get_ontology_label = lambda curie: "child term one"  # type: ignore[method-assign]
+
+    results = list(
+        plugin._validate_label(
+            value={"label": ["alternate label", "wrong label"]},
+            field_value="TEST:0000002",
+            slot_name="term",
+            instance={"term": {"id": "TEST:0000002", "label": ["alternate label", "wrong label"]}},
+            target_class="Annotation",
+            path="term",
+        )
+    )
+
+    assert len(results) == 1
+    assert results[0].type == "binding_label_mismatch"
+    assert "child term one" in results[0].message
+
+
 def test_binding_plugin_validates_nested_bindings(plugin_cache_dir, tmp_path):
     """Test that BindingValidationPlugin recurses into nested structures.
 


### PR DESCRIPTION
## Summary
- warn instead of crashing when a binding label field is not a string
- support multivalued label fields by accepting any string label that matches the ontology label
- keep mismatch warnings when no provided string label matches

Closes #38.

## Tests
- uv run pytest tests/test_plugins.py -q
- just test